### PR TITLE
Category clustering, creator enrichment, and title refinement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 .env
 .worktrees/
 .DS_Store
+.claude/settings.local.json
 knowledge/**/*.html
 logs/*.json
 data/

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A reusable template for building domain-specific [MCP](https://modelcontextproto
 
 ```bash
 # Use GitHub's "Use this template" button, or:
-gh repo create my-knowledge-server --template mriechers/mcp-knowledge-server-template
+gh repo create my-knowledge-server --template your-username/crows-nest
 cd my-knowledge-server
 ```
 

--- a/config/launchd/com.crows-nest.listener.plist
+++ b/config/launchd/com.crows-nest.listener.plist
@@ -30,6 +30,8 @@
     <dict>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>SIGNAL_USER</key>
+        <string>+1XXXXXXXXXX</string>
     </dict>
 
     <key>RunAtLoad</key>

--- a/config/systemd/crows-nest-listener.service
+++ b/config/systemd/crows-nest-listener.service
@@ -9,6 +9,7 @@ WorkingDirectory=/opt/crows-nest/pipeline
 Environment=CROWS_NEST_HOME=/opt/crows-nest
 Environment=OBSIDIAN_VAULT=/data/obsidian/MarkBrain
 Environment=MEDIA_ROOT=/data/media/crows-nest
+Environment=SIGNAL_USER=+1XXXXXXXXXX
 # Secrets: set these or use keychain_secrets env var fallback
 # Environment=OPENROUTER_API_KEY=sk-...
 

--- a/pipeline/consolidator.py
+++ b/pipeline/consolidator.py
@@ -367,7 +367,7 @@ Return a JSON object with:
             headers={
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {api_key}",
-                "HTTP-Referer": "https://github.com/mriechers/crows-nest",
+                "HTTP-Referer": "https://github.com/crows-nest-pipeline/crows-nest",
                 "X-Title": "Crow's Nest Consolidator",
             },
             method="POST",

--- a/pipeline/signal_listener.py
+++ b/pipeline/signal_listener.py
@@ -20,7 +20,7 @@ from utils import extract_urls, setup_logging
 logger = setup_logging("signal_listener")
 
 SIGNAL_CLI = "signal-cli"
-SIGNAL_USER = "SIGNAL_PHONE_NUMBER"
+SIGNAL_USER = os.environ.get("SIGNAL_USER", "")
 RECEIVE_TIMEOUT = 15
 SIGNAL_ATTACHMENTS_DIR = os.path.expanduser("~/.local/share/signal-cli/attachments")
 
@@ -267,6 +267,9 @@ def _log_message(sender: str, body: str, group: str = "") -> None:
 def run(db_path: str) -> None:
     """Main entry point: receive messages, extract URLs, store, confirm.
 
+    Requires SIGNAL_USER env var to be set to the phone number registered
+    with signal-cli (e.g. +15551234567).
+
     Receives messages, batches image attachments, then:
     - Non-image messages: log, store in signal_messages, extract URLs, add_link
     - Image batches: generate synthetic URL, add_link with image metadata
@@ -274,6 +277,10 @@ def run(db_path: str) -> None:
     Args:
         db_path: Path to the SQLite database file.
     """
+    if not SIGNAL_USER:
+        logger.error("SIGNAL_USER env var not set — cannot receive messages")
+        return
+
     init_db(db_path)
     messages = receive_messages()
 

--- a/pipeline/summarizer.py
+++ b/pipeline/summarizer.py
@@ -334,7 +334,7 @@ Content:
             headers={
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {api_key}",
-                "HTTP-Referer": "https://github.com/mriechers/crows-nest",
+                "HTTP-Referer": "https://github.com/crows-nest-pipeline/crows-nest",
                 "X-Title": "Crow's Nest Pipeline",
             },
             method="POST",
@@ -481,7 +481,7 @@ Return a JSON object with these exact keys:
             headers={
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {api_key}",
-                "HTTP-Referer": "https://github.com/mriechers/crows-nest",
+                "HTTP-Referer": "https://github.com/crows-nest-pipeline/crows-nest",
                 "X-Title": "Crow's Nest Pipeline",
             },
             method="POST",
@@ -696,7 +696,7 @@ def _refine_title_with_enrichment(claude_result: dict) -> dict:
             headers={
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {api_key}",
-                "HTTP-Referer": "https://github.com/mriechers/crows-nest",
+                "HTTP-Referer": "https://github.com/crows-nest-pipeline/crows-nest",
                 "X-Title": "Crow's Nest Pipeline",
             },
             method="POST",

--- a/tests/pipeline/test_add_link.py
+++ b/tests/pipeline/test_add_link.py
@@ -1,10 +1,11 @@
 """Tests for the add_link.py CLI tool."""
 
+import os
 import sqlite3
 import subprocess
 import sys
 
-SCRIPT = "/PATH/TO/crows-nest/pipeline/add_link.py"
+SCRIPT = os.path.join(os.path.dirname(__file__), "../../pipeline/add_link.py")
 
 
 def test_add_link_cli(tmp_path):


### PR DESCRIPTION
## Summary

- **Category clustering**: Consolidator now groups notes by broad content categories (film, product, book, podcast, etc.) using fuzzy tag root matching — `horror-films`, `film-review`, and `independent-film` all resolve to the `film` category root. Default `min_cluster_size` lowered from 3 to 2. Category roundups append to existing notes on subsequent runs (living documents).
- **Creator enrichment**: When the summarizer detects a creator name + category tag, it searches DuckDuckGo for the creator's specific work and adds up to 2 reference links. Cost: ~1 second, $0 API cost.
- **Title refinement**: After enrichment, a lightweight Haiku call refines the note title to include the specific artifact name (e.g. "The ADHD Field Guide Release Day" instead of "Book Release Day"). Cost: ~$0.001 per enriched item.
- **Config fixes**: Vault path default updated to `~/Developer/second-brain/obsidian/MarkBrain`, clippings folder casing corrected to `CLIPPINGS`.
- **AGENTS.md**: Updated to match CLAUDE.md content (was stale template).

## Test plan

- [x] 18 consolidator tests pass (including 7 new: category root detection, fuzzy compound tag clustering, cross-category separation, append-to-roundup, duplicate skipping)
- [x] 106 total tests pass across the full suite
- [x] Live test: consolidated 28 clippings into 4 roundups (6 films, 5 tools, 2 mental health, 2 multi-agent)
- [x] Live test: re-ran summarizer for catieosaurus TikTok — enrichment found "The ADHD Field Guide for Adults" on Barnes & Noble, title refined to include book name
- [ ] Monitor enrichment on next batch of Signal imports for false positives or missed categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)