### PR TITLE
refactor: media store, video preservation, R2 credentials, semantic search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ build/
 knowledge/**/*.html
 logs/*.json
 data/
+media/
 *.db

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,17 @@ The pipeline runs on macOS and Linux. Platform-specific behavior:
 - Secrets: macOS Keychain with env var fallback — on Linux, just set env vars
 - All paths configurable via env vars in `config.py`
 
+### R2 Archival Credentials
+
+Store in macOS Keychain:
+```bash
+security add-generic-password -a "$USER" -s "developer.workspace.R2_ACCESS_KEY_ID" -w "your-key" -U
+security add-generic-password -a "$USER" -s "developer.workspace.R2_SECRET_ACCESS_KEY" -w "your-secret" -U
+security add-generic-password -a "$USER" -s "developer.workspace.R2_ENDPOINT_URL" -w "https://<account-id>.r2.cloudflarestorage.com" -U
+```
+
+Or set environment variables with the same names.
+
 ## MCP Knowledge Server
 
 Domain-specific knowledge server (`src/mcp_knowledge/`) with search, categories, and document retrieval.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,14 +56,20 @@ Or set environment variables with the same names.
 
 ## MCP Knowledge Server
 
-Domain-specific knowledge server (`src/mcp_knowledge/`) with search, categories, and document retrieval.
+Domain-specific knowledge server (`src/mcp_knowledge/`) with keyword search over curated docs and semantic search over media archive transcripts.
 
-### Available Tools
+### Keyword Search Tools
 
 - `search_knowledge(query, category?, max_results=5, full_document=False)` — keyword search with excerpts
 - `list_topics()` — categories with document counts
 - `get_document(path)` — fetch full document by path
 - `get_server_info()` — server metadata
+
+### Semantic Search Tools (requires `pip install -e ".[semantic]"`)
+
+- `semantic_search(query, n_results=10, platform?)` — search media archive transcripts via natural language
+- `reindex_media()` — rebuild semantic index from media archive
+- `media_status()` — semantic index health: document count, collection info
 
 ### Knowledge Structure
 
@@ -77,3 +83,41 @@ knowledge/
 ```
 
 To add knowledge: add to `sources.json` and run `python scripts/crawl_docs.py`, or manually create `.md` files.
+
+### Media Archive
+
+Pipeline output stored in `media/` (gitignored). Structure:
+```
+media/
+  YYYY-MM/
+    item-title/
+      metadata.json     # Rich metadata (title, creator, platform, url, etc.)
+      item-title.txt    # Whisper transcript
+      item-title.mp4    # Video file (when available)
+      item-title.m4a    # Audio file
+```
+
+### HTTP API
+
+Optional localhost HTTP API. Enable via `CROWS_NEST_HTTP_API=true` env var.
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/search` | POST | Combined semantic + keyword search (`{query, n_results?, platform?}`) |
+| `/status` | GET | Index health dashboard |
+| `/reindex` | POST | Trigger media archive reindex |
+| `/health` | GET | Liveness check |
+
+Default port: 27185. Override: `CROWS_NEST_HTTP_PORT`.
+
+## Development
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"              # base + tests
+pip install -e ".[semantic]"         # + ChromaDB, fastembed
+pip install -e ".[archive]"          # + boto3 for R2
+pip install -e ".[all]"              # everything
+pytest tests/
+```

--- a/pipeline/archiver.py
+++ b/pipeline/archiver.py
@@ -3,7 +3,7 @@ Archiver for the Crow's Nest pipeline.
 
 Stage 4: creates tar.gz archives of captured media directories, generates
 SHA-256 manifests, and uploads both to the crows-nest-archive R2 bucket via
-wrangler. Runs daily; processes all links with status="summarized".
+boto3 (S3-compatible). Runs daily; processes all links with status="summarized".
 """
 
 import argparse
@@ -11,12 +11,15 @@ import hashlib
 import json
 import os
 import shutil
-import subprocess
 import tarfile
 import tempfile
 from datetime import datetime, timezone
 
+import boto3
+from botocore.config import Config as BotoConfig
+
 from db import DB_PATH, claim_link, get_pending, log_processing, update_status
+from keychain_secrets import get_secret
 from utils import setup_logging
 
 logger = setup_logging("crows-nest.archiver")
@@ -65,43 +68,30 @@ def create_archive(media_dir: str, output_path: str) -> list[dict]:
     return inventory
 
 
-def upload_to_r2(local_path: str, r2_key: str) -> bool:
-    """Upload local_path to R2 at {R2_BUCKET}/{r2_key} via wrangler.
+def get_r2_client():
+    """Create an S3-compatible client for Cloudflare R2."""
+    endpoint = get_secret("R2_ENDPOINT_URL", required=True)
+    access_key = get_secret("R2_ACCESS_KEY_ID", required=True)
+    secret_key = get_secret("R2_SECRET_ACCESS_KEY", required=True)
 
-    Returns True on success, False on failure.
-    """
-    cmd = [
-        "wrangler",
-        "r2",
-        "object",
-        "put",
-        f"{R2_BUCKET}/{r2_key}",
-        "--file",
-        local_path,
-        "--storage-class",
-        "InfrequentAccess",
-    ]
-    logger.info("uploading %s -> r2://%s/%s", local_path, R2_BUCKET, r2_key)
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        config=BotoConfig(retries={"max_attempts": 3, "mode": "adaptive"}),
+    )
+
+
+def upload_to_r2(local_path: str, r2_key: str) -> bool:
+    """Upload a file to R2. Returns True on success."""
     try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=300,
-        )
-        if result.returncode == 0:
-            logger.info("upload succeeded: %s", r2_key)
-            return True
-        else:
-            logger.error(
-                "wrangler exited %d: %s", result.returncode, result.stderr.strip()
-            )
-            return False
-    except subprocess.TimeoutExpired:
-        logger.error("upload timed out: %s", r2_key)
-        return False
-    except Exception as exc:
-        logger.error("upload error for %s: %s", r2_key, exc)
+        client = get_r2_client()
+        client.upload_file(local_path, R2_BUCKET, r2_key)
+        logger.info("Uploaded %s -> r2://%s/%s", local_path, R2_BUCKET, r2_key)
+        return True
+    except Exception as e:
+        logger.error("R2 upload failed for %s: %s", r2_key, e)
         return False
 
 

--- a/pipeline/archiver.py
+++ b/pipeline/archiver.py
@@ -106,7 +106,7 @@ def _r2_key_from_media_path(media_path: str, title: str) -> str:
     Pattern: {YYYY}/{MM}/{title}.tar.gz
     Falls back to today's date if the path doesn't contain a YYYY-MM segment.
     """
-    # media_path is typically ~/Media/crows-nest/YYYY-MM/sanitized-title
+    # media_path is typically {CROWS_NEST_HOME}/media/YYYY-MM/sanitized-title
     basename = os.path.basename(media_path.rstrip("/"))
     parent = os.path.basename(os.path.dirname(media_path.rstrip("/")))
 

--- a/pipeline/backfill_video.py
+++ b/pipeline/backfill_video.py
@@ -1,0 +1,200 @@
+"""
+One-shot backfill script: download video for items that have audio but no video.
+
+Targets links where:
+  - content_type in ('youtube', 'social_video', 'podcast')
+  - download_path is not NULL
+  - video_path IS NULL or empty string
+  - status in ('transcribed', 'summarized', 'archived')
+
+Usage:
+    python backfill_video.py [--dry-run] [--limit N] [--db PATH]
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+from db import DB_PATH, get_connection, update_status
+
+# Storage estimates per content type
+_SIZE_ESTIMATES_MB = {
+    "social_video": 50,
+    "youtube": 500,
+    "podcast": 500,
+}
+
+R2_COST_PER_GB_MONTH = 0.015
+
+
+def query_candidates(db_path: str, limit: int | None = None) -> list[dict]:
+    """Return links that have audio but no video."""
+    sql = """
+        SELECT id, url, content_type, download_path, status
+        FROM links
+        WHERE content_type IN ('youtube', 'social_video', 'podcast')
+          AND download_path IS NOT NULL
+          AND download_path != ''
+          AND (video_path IS NULL OR video_path = '')
+          AND status IN ('transcribed', 'summarized', 'archived')
+        ORDER BY created_at ASC
+    """
+    if limit is not None:
+        sql += f" LIMIT {int(limit)}"
+
+    conn = get_connection(db_path)
+    try:
+        cursor = conn.execute(sql)
+        return [dict(row) for row in cursor.fetchall()]
+    finally:
+        conn.close()
+
+
+def storage_estimate(candidates: list[dict]) -> tuple[float, float]:
+    """Return (total_mb, r2_monthly_cost)."""
+    total_mb = sum(
+        _SIZE_ESTIMATES_MB.get(row["content_type"], 500) for row in candidates
+    )
+    total_gb = total_mb / 1024
+    cost = total_gb * R2_COST_PER_GB_MONTH
+    return total_mb, cost
+
+
+def find_new_video(media_dir: str, before: set[str]) -> str | None:
+    """Return the first .mp4/.mkv/.webm file in media_dir that was not in before."""
+    for name in os.listdir(media_dir):
+        if name.endswith((".mp4", ".mkv", ".webm")):
+            full = os.path.join(media_dir, name)
+            if full not in before:
+                return full
+    return None
+
+
+def existing_videos(media_dir: str) -> set[str]:
+    """Return the set of video file paths currently in media_dir."""
+    result = set()
+    if not os.path.isdir(media_dir):
+        return result
+    for name in os.listdir(media_dir):
+        if name.endswith((".mp4", ".mkv", ".webm")):
+            result.add(os.path.join(media_dir, name))
+    return result
+
+
+def download_video(url: str, media_dir: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            "yt-dlp",
+            "--format", "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
+            "--merge-output-format", "mp4",
+            "--output", os.path.join(media_dir, "%(title)s.%(ext)s"),
+            url,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill video downloads for items that only have audio."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show candidates and storage estimate without downloading.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Process at most N items.",
+    )
+    parser.add_argument(
+        "--db",
+        default=DB_PATH,
+        metavar="PATH",
+        help=f"Database path (default: {DB_PATH})",
+    )
+    args = parser.parse_args()
+
+    candidates = query_candidates(args.db, args.limit)
+
+    if not candidates:
+        print("No candidates found. Nothing to do.")
+        return
+
+    total_mb, r2_cost = storage_estimate(candidates)
+
+    print(f"Found {len(candidates)} candidate(s) with audio but no video.")
+    print(f"Storage estimate: ~{total_mb:.0f} MB (~{total_mb / 1024:.2f} GB)")
+    print(f"R2 cost estimate: ~${r2_cost:.4f}/month")
+    print()
+
+    if args.dry_run:
+        print("Candidates (dry run — no downloads):")
+        for i, row in enumerate(candidates, 1):
+            est = _SIZE_ESTIMATES_MB.get(row["content_type"], 500)
+            print(
+                f"  [{i}/{len(candidates)}] [{row['content_type']}] "
+                f"~{est} MB  {row['url']}"
+            )
+        return
+
+    downloaded = 0
+    failed = 0
+
+    for i, row in enumerate(candidates, 1):
+        link_id = row["id"]
+        url = row["url"]
+        media_dir = row["download_path"]
+
+        print(f"[{i}/{len(candidates)}] {url}... ", end="", flush=True)
+
+        if not os.path.isdir(media_dir):
+            print(f"Failed to download video (media_dir not found: {media_dir})")
+            failed += 1
+            continue
+
+        before = existing_videos(media_dir)
+
+        try:
+            result = download_video(url, media_dir)
+        except subprocess.TimeoutExpired:
+            print("Failed to download video (timeout after 600s)")
+            failed += 1
+            continue
+
+        if result.returncode != 0:
+            print("Failed to download video")
+            failed += 1
+            continue
+
+        video_file = find_new_video(media_dir, before)
+        if not video_file:
+            print("Failed to download video (file not found after yt-dlp succeeded)")
+            failed += 1
+            continue
+
+        size_mb = os.path.getsize(video_file) / (1024 * 1024)
+        print(f"Downloaded: {os.path.basename(video_file)} ({size_mb:.1f} MB)")
+
+        update_status(
+            link_id,
+            row["status"],  # preserve existing status
+            db_path=args.db,
+            video_path=video_file,
+        )
+        downloaded += 1
+
+    print()
+    print(f"Done: {downloaded} downloaded, {failed} failed")
+
+
+if __name__ == "__main__":
+    # Ensure pipeline/ is on the path when run directly
+    sys.path.insert(0, os.path.dirname(__file__))
+    main()

--- a/pipeline/backfill_video.py
+++ b/pipeline/backfill_video.py
@@ -169,7 +169,8 @@ def main() -> None:
             continue
 
         if result.returncode != 0:
-            print("Failed to download video")
+            reason = result.stderr.strip()[:200] if result.stderr else "unknown error"
+            print(f"Failed to download video: {reason}")
             failed += 1
             continue
 

--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -7,7 +7,7 @@ vars to override:
 
     CROWS_NEST_HOME     — repo root (default: ~/Developer/second-brain/crows-nest)
     OBSIDIAN_VAULT      — vault root (default: ~/Developer/obsidian/MarkBrain)
-    MEDIA_ROOT          — media storage (default: ~/Media/crows-nest)
+    MEDIA_ROOT          — media storage (default: {CROWS_NEST_HOME}/media)
 
 Example systemd override:
     Environment=CROWS_NEST_HOME=/opt/crows-nest
@@ -35,7 +35,7 @@ OBSIDIAN_VAULT = os.environ.get(
 
 MEDIA_ROOT = os.environ.get(
     "MEDIA_ROOT",
-    os.path.expanduser("~/Media/crows-nest"),
+    os.path.join(CROWS_NEST_HOME, "media"),
 )
 
 # ---------------------------------------------------------------------------

--- a/pipeline/db.py
+++ b/pipeline/db.py
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS links (
     transcript_path  TEXT,
     obsidian_note_path TEXT,
     archive_path     TEXT,
+    video_path       TEXT,
     error            TEXT,
     retry_count      INTEGER NOT NULL DEFAULT 0,
     metadata         TEXT
@@ -75,6 +76,12 @@ def init_db(db_path: str = DB_PATH) -> None:
     try:
         conn.executescript(SCHEMA)
         conn.commit()
+        # Migrate existing databases: add video_path if missing
+        try:
+            conn.execute("ALTER TABLE links ADD COLUMN video_path TEXT")
+            conn.commit()
+        except sqlite3.OperationalError:
+            pass  # Column already exists
     finally:
         conn.close()
 

--- a/pipeline/migrate_media_paths.py
+++ b/pipeline/migrate_media_paths.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+One-shot migration: update stored media paths in SQLite from the old
+~/Media/crows-nest root to the new {CROWS_NEST_HOME}/media root.
+
+Safe to run multiple times — rows whose paths do not start with OLD_ROOT
+are left untouched (idempotent).
+
+Usage:
+    python pipeline/migrate_media_paths.py [--db <path>] [--dry-run]
+"""
+
+import argparse
+import os
+import sqlite3
+import sys
+
+# ---------------------------------------------------------------------------
+# Resolve paths
+# ---------------------------------------------------------------------------
+
+OLD_ROOT = os.path.expanduser("~/Media/crows-nest")
+
+CROWS_NEST_HOME = os.environ.get(
+    "CROWS_NEST_HOME",
+    os.path.expanduser("~/Developer/second-brain/crows-nest"),
+)
+NEW_ROOT = os.environ.get(
+    "MEDIA_ROOT",
+    os.path.join(CROWS_NEST_HOME, "media"),
+)
+
+# Fall back to config module's DB_PATH if available
+try:
+    sys.path.insert(0, os.path.dirname(__file__))
+    from config import DB_PATH as _DEFAULT_DB_PATH
+except ImportError:
+    _DEFAULT_DB_PATH = os.path.join(CROWS_NEST_HOME, "data", "crows-nest.db")
+
+
+# ---------------------------------------------------------------------------
+# Migration logic
+# ---------------------------------------------------------------------------
+
+def _reroot(value: str | None, old: str, new: str) -> str | None:
+    """Replace old root prefix with new root in a path string."""
+    if value and value.startswith(old):
+        return new + value[len(old):]
+    return value
+
+
+def migrate(db_path: str, dry_run: bool = False) -> int:
+    """
+    Update download_path and transcript_path in the links table.
+
+    Returns the number of rows whose paths were updated.
+    """
+    if not os.path.exists(db_path):
+        print(f"Database not found: {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT id, download_path, transcript_path FROM links"
+        ).fetchall()
+
+        updated = 0
+        for row in rows:
+            new_download = _reroot(row["download_path"], OLD_ROOT, NEW_ROOT)
+            new_transcript = _reroot(row["transcript_path"], OLD_ROOT, NEW_ROOT)
+
+            changed = (
+                new_download != row["download_path"]
+                or new_transcript != row["transcript_path"]
+            )
+            if not changed:
+                continue
+
+            updated += 1
+            if dry_run:
+                print(
+                    f"[dry-run] row {row['id']}: "
+                    f"download_path {row['download_path']!r} -> {new_download!r}  |  "
+                    f"transcript_path {row['transcript_path']!r} -> {new_transcript!r}"
+                )
+            else:
+                conn.execute(
+                    "UPDATE links SET download_path = ?, transcript_path = ? WHERE id = ?",
+                    (new_download, new_transcript, row["id"]),
+                )
+
+        if not dry_run:
+            conn.commit()
+
+    finally:
+        conn.close()
+
+    return updated
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db",
+        default=_DEFAULT_DB_PATH,
+        help=f"Path to the SQLite database (default: {_DEFAULT_DB_PATH})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would change without modifying the database",
+    )
+    args = parser.parse_args()
+
+    print(f"Old root: {OLD_ROOT}")
+    print(f"New root: {NEW_ROOT}")
+    print(f"Database: {args.db}")
+    if args.dry_run:
+        print("Mode: dry-run (no changes will be written)")
+    print()
+
+    count = migrate(args.db, dry_run=args.dry_run)
+
+    if args.dry_run:
+        print(f"\n{count} row(s) would be updated.")
+    else:
+        print(f"{count} row(s) updated.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/processor.py
+++ b/pipeline/processor.py
@@ -895,19 +895,25 @@ def process_video(
     video_file = None
     if not transcript_path:
         # 3a: Try full video download first (mp4 preferred)
-        vid_result = subprocess.run(
-            [
-                "yt-dlp",
-                "--format", "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
-                "--merge-output-format", "mp4",
-                "--output", os.path.join(media_dir, "%(title)s.%(ext)s"),
-                url,
-            ],
-            capture_output=True,
-            text=True,
-        )
+        try:
+            vid_result = subprocess.run(
+                [
+                    "yt-dlp",
+                    "--format", "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
+                    "--merge-output-format", "mp4",
+                    "--output", os.path.join(media_dir, "%(title)s.%(ext)s"),
+                    url,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning("link %d: video download timed out after 600s, "
+                           "falling back to audio-only download", link_id)
+            vid_result = None
 
-        if vid_result.returncode == 0:
+        if vid_result is not None and vid_result.returncode == 0:
             # Find the downloaded video file
             for name in os.listdir(media_dir):
                 if name.endswith((".mp4", ".mkv", ".webm")):

--- a/pipeline/processor.py
+++ b/pipeline/processor.py
@@ -890,14 +890,16 @@ def process_video(
         except Exception as exc:
             logger.info("link %d: subtitle fetch failed (non-fatal): %s", link_id, exc)
 
-    # Step 3: Download audio only if we need Whisper
+    # Step 3: Download video (preserving the file) and extract audio for Whisper
     audio_file = None
+    video_file = None
     if not transcript_path:
-        result = subprocess.run(
+        # 3a: Try full video download first (mp4 preferred)
+        vid_result = subprocess.run(
             [
                 "yt-dlp",
-                "--extract-audio",
-                "--audio-format", "m4a",
+                "--format", "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
+                "--merge-output-format", "mp4",
                 "--output", os.path.join(media_dir, "%(title)s.%(ext)s"),
                 url,
             ],
@@ -905,38 +907,75 @@ def process_video(
             text=True,
         )
 
-        if result.returncode != 0:
-            # yt-dlp failed (DRM, geo-block, etc.) — try RSS audio URL fallback
-            if rss_audio_url:
-                logger.info("link %d: yt-dlp failed, trying RSS audio URL: %s",
-                            link_id, rss_audio_url[:80])
-                audio_filename = sanitize_title(
-                    yt_metadata.get("title") or "episode"
-                ) + ".mp3"
-                audio_path = os.path.join(media_dir, audio_filename)
-                dl_result = subprocess.run(
-                    ["curl", "-sL", "--max-time", "300", "-o", audio_path, rss_audio_url],
-                    capture_output=True, text=True,
-                )
-                if dl_result.returncode == 0 and os.path.exists(audio_path):
-                    audio_file = audio_path
-                    logger.info("link %d: downloaded audio via RSS fallback", link_id)
-                else:
-                    raise RuntimeError(
-                        f"yt-dlp failed ({result.stderr.strip()[:200]}) "
-                        f"and RSS audio fallback also failed"
-                    )
-            else:
-                raise RuntimeError(f"yt-dlp failed: {result.stderr[:500]}")
-
-        if not audio_file:
+        if vid_result.returncode == 0:
+            # Find the downloaded video file
             for name in os.listdir(media_dir):
-                if name.endswith((".m4a", ".mp3", ".wav", ".opus", ".webm")):
-                    audio_file = os.path.join(media_dir, name)
+                if name.endswith((".mp4", ".mkv", ".webm")):
+                    video_file = os.path.join(media_dir, name)
                     break
 
+        if video_file:
+            # 3b: Extract audio from the video via ffmpeg
+            audio_filename = os.path.splitext(os.path.basename(video_file))[0] + ".m4a"
+            audio_path = os.path.join(media_dir, audio_filename)
+            ffmpeg_result = subprocess.run(
+                ["ffmpeg", "-i", video_file, "-vn", "-acodec", "aac", "-y", audio_path],
+                capture_output=True, text=True,
+            )
+            if ffmpeg_result.returncode == 0 and os.path.exists(audio_path):
+                audio_file = audio_path
+                logger.info("link %d: extracted audio from video: %s", link_id, audio_path)
+            else:
+                logger.warning("link %d: ffmpeg audio extraction failed, "
+                               "falling back to audio-only download", link_id)
+                # Fall through to audio-only download below
+
+        # 3c: Fall back to audio-only download if no audio extracted yet
         if not audio_file:
-            raise RuntimeError("audio download succeeded but no audio file found in media_dir")
+            result = subprocess.run(
+                [
+                    "yt-dlp",
+                    "--extract-audio",
+                    "--audio-format", "m4a",
+                    "--output", os.path.join(media_dir, "%(title)s.%(ext)s"),
+                    url,
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            if result.returncode != 0:
+                # yt-dlp failed (DRM, geo-block, etc.) — try RSS audio URL fallback
+                if rss_audio_url:
+                    logger.info("link %d: yt-dlp failed, trying RSS audio URL: %s",
+                                link_id, rss_audio_url[:80])
+                    audio_filename = sanitize_title(
+                        yt_metadata.get("title") or "episode"
+                    ) + ".mp3"
+                    audio_path = os.path.join(media_dir, audio_filename)
+                    dl_result = subprocess.run(
+                        ["curl", "-sL", "--max-time", "300", "-o", audio_path, rss_audio_url],
+                        capture_output=True, text=True,
+                    )
+                    if dl_result.returncode == 0 and os.path.exists(audio_path):
+                        audio_file = audio_path
+                        logger.info("link %d: downloaded audio via RSS fallback", link_id)
+                    else:
+                        raise RuntimeError(
+                            f"yt-dlp failed ({result.stderr.strip()[:200]}) "
+                            f"and RSS audio fallback also failed"
+                        )
+                else:
+                    raise RuntimeError(f"yt-dlp failed: {result.stderr[:500]}")
+
+            if not audio_file:
+                for name in os.listdir(media_dir):
+                    if name.endswith((".m4a", ".mp3", ".wav", ".opus", ".webm")):
+                        audio_file = os.path.join(media_dir, name)
+                        break
+
+            if not audio_file:
+                raise RuntimeError("audio download succeeded but no audio file found in media_dir")
 
     # Derive video title from downloaded file or metadata
     video_title = ""
@@ -984,7 +1023,8 @@ def process_video(
         json.dump(metadata, f, indent=2)
 
     update_status(link_id=link_id, status="downloading",
-                  download_path=audio_file or "", db_path=db_path)
+                  download_path=media_dir, video_path=video_file or "",
+                  db_path=db_path)
 
     # Step 4: Transcribe with Whisper if no subtitles were found
     if not transcript_path:
@@ -1005,6 +1045,7 @@ def process_video(
         link_id=link_id,
         status="transcribed",
         transcript_path=transcript_path,
+        video_path=video_file or "",
         db_path=db_path,
     )
     log_processing(link_id, "process_video", "success",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ mcp-knowledge-server = "mcp_knowledge.server:main"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0"]
+archive = ["boto3>=1.28"]
+semantic = ["chromadb>=0.5", "fastembed>=0.3"]
+all = ["crows-nest[archive,semantic]"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mcp_knowledge"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "crows-nest"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP knowledge server and Signal-to-Obsidian content preservation pipeline"
 requires-python = ">=3.11"
 dependencies = [
@@ -12,7 +12,7 @@ dependencies = [
 mcp-knowledge-server = "mcp_knowledge.server:main"
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0"]
+dev = ["pytest>=7.0", "httpx>=0.24"]
 archive = ["boto3>=1.28"]
 semantic = ["chromadb>=0.5", "fastembed>=0.3"]
 all = ["crows-nest[archive,semantic]"]

--- a/src/mcp_knowledge/api.py
+++ b/src/mcp_knowledge/api.py
@@ -22,29 +22,41 @@ def create_api(semantic_index, knowledge_base=None) -> Starlette:
     """Create the HTTP API application."""
 
     async def search(request: Request) -> JSONResponse:
-        body = await request.json()
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+
         query = body.get("query")
         if not query:
             return JSONResponse({"error": "query is required"}, status_code=400)
         n_results = body.get("n_results", 10)
         platform = body.get("platform")
 
-        # Semantic search over media archive
-        semantic_results = await asyncio.to_thread(
-            semantic_index.search, query=query, n_results=n_results, platform=platform,
-        )
-
-        # Keyword search over knowledge base (if available)
-        keyword_results = []
-        if knowledge_base:
-            keyword_results = await asyncio.to_thread(
-                knowledge_base.search_knowledge, query=query, max_results=n_results,
+        try:
+            # Semantic search over media archive
+            semantic_results = await asyncio.to_thread(
+                semantic_index.search, query=query, n_results=n_results, platform=platform,
             )
 
-        return JSONResponse({"results": semantic_results + keyword_results})
+            # Keyword search over knowledge base (if available)
+            keyword_results = []
+            if knowledge_base:
+                keyword_results = await asyncio.to_thread(
+                    knowledge_base.search_knowledge, query=query, max_results=n_results,
+                )
+
+            return JSONResponse({"results": semantic_results + keyword_results})
+        except Exception as exc:
+            logger.exception("Search failed")
+            return JSONResponse({"error": str(exc)}, status_code=500)
 
     async def status(request: Request) -> JSONResponse:
-        semantic_status = await asyncio.to_thread(semantic_index.get_status)
+        try:
+            semantic_status = await asyncio.to_thread(semantic_index.get_status)
+        except Exception as exc:
+            logger.exception("Status check failed")
+            return JSONResponse({"error": str(exc)}, status_code=500)
         return JSONResponse({"semantic": semantic_status, "service": "crows-nest"})
 
     async def reindex(request: Request) -> JSONResponse:

--- a/src/mcp_knowledge/api.py
+++ b/src/mcp_knowledge/api.py
@@ -1,0 +1,81 @@
+"""HTTP API for crows-nest — serves search over knowledge base and media archive.
+
+Endpoints:
+    POST /search       — Combined semantic + keyword search
+    GET  /status       — Index health dashboard
+    POST /reindex      — Trigger media archive reindex
+    GET  /health       — Simple liveness check
+"""
+import asyncio
+import logging
+
+from starlette.applications import Starlette
+from starlette.middleware.cors import CORSMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+logger = logging.getLogger("mcp_knowledge.api")
+
+
+def create_api(semantic_index, knowledge_base=None) -> Starlette:
+    """Create the HTTP API application."""
+
+    async def search(request: Request) -> JSONResponse:
+        body = await request.json()
+        query = body.get("query")
+        if not query:
+            return JSONResponse({"error": "query is required"}, status_code=400)
+        n_results = body.get("n_results", 10)
+        platform = body.get("platform")
+
+        # Semantic search over media archive
+        semantic_results = await asyncio.to_thread(
+            semantic_index.search, query=query, n_results=n_results, platform=platform,
+        )
+
+        # Keyword search over knowledge base (if available)
+        keyword_results = []
+        if knowledge_base:
+            keyword_results = await asyncio.to_thread(
+                knowledge_base.search_knowledge, query=query, max_results=n_results,
+            )
+
+        return JSONResponse({"results": semantic_results + keyword_results})
+
+    async def status(request: Request) -> JSONResponse:
+        semantic_status = await asyncio.to_thread(semantic_index.get_status)
+        return JSONResponse({"semantic": semantic_status, "service": "crows-nest"})
+
+    async def reindex(request: Request) -> JSONResponse:
+        return JSONResponse({"error": "reindex not yet wired"}, status_code=501)
+
+    async def health(request: Request) -> JSONResponse:
+        return JSONResponse({"status": "ok", "service": "crows-nest"})
+
+    app = Starlette(
+        routes=[
+            Route("/search", search, methods=["POST"]),
+            Route("/status", status, methods=["GET"]),
+            Route("/reindex", reindex, methods=["POST"]),
+            Route("/health", health, methods=["GET"]),
+        ],
+    )
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["app://obsidian.md", "http://localhost", "http://127.0.0.1"],
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["*"],
+    )
+    return app
+
+
+async def start_api_server(semantic_index, knowledge_base=None,
+                           host="127.0.0.1", port=27185, log_level="info"):
+    """Start the HTTP API server as a background task."""
+    import uvicorn
+    app = create_api(semantic_index, knowledge_base)
+    config = uvicorn.Config(app, host=host, port=port, log_level=log_level)
+    server = uvicorn.Server(config)
+    logger.info("HTTP API starting on %s:%d", host, port)
+    await server.serve()

--- a/src/mcp_knowledge/config.py
+++ b/src/mcp_knowledge/config.py
@@ -1,5 +1,6 @@
 """Configuration constants — edit these when forking for your domain."""
 
+import os
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -38,3 +39,35 @@ TITLE_FULL_MATCH_BOOST = 50
 
 # Score boost per individual query term that appears in a document's title.
 TITLE_TERM_BOOST = 10
+
+# ---------------------------------------------------------------------------
+# Media archive
+# ---------------------------------------------------------------------------
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Path to the media archive directory (pipeline output)
+MEDIA_ROOT = os.environ.get(
+    "CROWS_NEST_MEDIA_ROOT",
+    str(_PROJECT_ROOT / "media"),
+)
+
+# ---------------------------------------------------------------------------
+# Semantic search
+# ---------------------------------------------------------------------------
+
+SEMANTIC_DATA_DIR = os.environ.get(
+    "CROWS_NEST_SEMANTIC_DATA",
+    str(Path(os.path.expanduser("~/.local/share/crows-nest/data/chroma"))),
+)
+EMBEDDING_MODEL = "BAAI/bge-small-en-v1.5"
+
+# ---------------------------------------------------------------------------
+# HTTP API
+# ---------------------------------------------------------------------------
+
+ENABLE_HTTP_API = os.environ.get(
+    "CROWS_NEST_HTTP_API", "false"
+).lower() in ("true", "1", "yes")
+HTTP_PORT = int(os.environ.get("CROWS_NEST_HTTP_PORT", "27185"))
+HTTP_HOST = os.environ.get("CROWS_NEST_HTTP_HOST", "127.0.0.1")

--- a/src/mcp_knowledge/config.py
+++ b/src/mcp_knowledge/config.py
@@ -48,7 +48,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 # Path to the media archive directory (pipeline output)
 MEDIA_ROOT = os.environ.get(
-    "CROWS_NEST_MEDIA_ROOT",
+    "MEDIA_ROOT",
     str(_PROJECT_ROOT / "media"),
 )
 

--- a/src/mcp_knowledge/embeddings.py
+++ b/src/mcp_knowledge/embeddings.py
@@ -1,0 +1,21 @@
+"""Lazy fastembed wrapper for generating text embeddings."""
+from typing import Any
+
+
+class EmbeddingProvider:
+    """Thin wrapper around fastembed with lazy model loading."""
+
+    def __init__(self, model_name: str = "BAAI/bge-small-en-v1.5") -> None:
+        self._model_name = model_name
+        self._model: Any = None
+
+    def _ensure_model(self) -> None:
+        if self._model is not None:
+            return
+        from fastembed import TextEmbedding
+        self._model = TextEmbedding(model_name=self._model_name)
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Return a list of float vectors, one per input text."""
+        self._ensure_model()
+        return [vec.tolist() for vec in self._model.embed(texts)]

--- a/src/mcp_knowledge/media_loader.py
+++ b/src/mcp_knowledge/media_loader.py
@@ -1,0 +1,150 @@
+"""Media archive document loader.
+
+Walks the media archive directory structure and loads documents for indexing.
+
+Media archive layout::
+
+    media_root/
+        YYYY-MM/
+            item-title/
+                metadata.json      -- rich metadata (title, creator, platform, url, ...)
+                item-title.txt     -- Whisper transcript
+                page.txt           -- web page content (web_page content type)
+                article.md         -- scraped article markdown
+                *.m4a, *.mp4       -- media files (not loaded)
+
+Each loaded document is a dict with keys: title, text, path, metadata.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Month directory pattern: YYYY-MM
+_MONTH_RE = re.compile(r"^\d{4}-\d{2}$")
+
+# Text files that indicate web page / article content (checked first, in order)
+_WEB_PAGE_NAMES = ("page.txt", "article.md")
+
+
+def _read_text(path: str) -> str:
+    """Read a text file, returning its contents as a string."""
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _load_metadata(item_dir: str) -> dict[str, Any]:
+    """Load metadata.json from item_dir, returning {} if absent or malformed."""
+    meta_path = os.path.join(item_dir, "metadata.json")
+    if not os.path.isfile(meta_path):
+        return {}
+    try:
+        with open(meta_path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Failed to load metadata at %s: %s", meta_path, exc)
+        return {}
+
+
+def _find_text_content(item_dir: str) -> str | None:
+    """Return the text content for this item directory, or None if not found.
+
+    Priority order:
+    1. page.txt (web page content)
+    2. article.md (scraped article)
+    3. Any .txt file that is not metadata.json (Whisper transcript)
+    """
+    # 1 & 2: preferred web page / article files
+    for name in _WEB_PAGE_NAMES:
+        candidate = os.path.join(item_dir, name)
+        if os.path.isfile(candidate):
+            return _read_text(candidate)
+
+    # 3: fall back to any .txt file (transcript)
+    try:
+        entries = os.listdir(item_dir)
+    except OSError:
+        return None
+
+    for name in sorted(entries):
+        if name.endswith(".txt") and name != "metadata.json":
+            return _read_text(os.path.join(item_dir, name))
+
+    return None
+
+
+def load_media_documents(media_root: str) -> list[dict[str, Any]]:
+    """Walk media_root and return a list of indexable document dicts.
+
+    Each dict has the shape::
+
+        {
+            "title": str,      # From metadata.json "title", fallback to dirname
+            "text": str,       # Transcript or page content
+            "path": str,       # Absolute path to item directory
+            "metadata": dict,  # Full metadata.json contents (or {})
+        }
+
+    Items without any text content are skipped.
+    A nonexistent media_root returns an empty list without raising.
+    """
+    if not os.path.isdir(media_root):
+        logger.debug("media_root does not exist or is not a directory: %s", media_root)
+        return []
+
+    documents: list[dict[str, Any]] = []
+
+    try:
+        month_entries = sorted(os.listdir(media_root))
+    except OSError as exc:
+        logger.error("Cannot list media_root %s: %s", media_root, exc)
+        return []
+
+    for month_name in month_entries:
+        if not _MONTH_RE.match(month_name):
+            continue
+
+        month_dir = os.path.join(media_root, month_name)
+        if not os.path.isdir(month_dir):
+            continue
+
+        try:
+            item_entries = sorted(os.listdir(month_dir))
+        except OSError as exc:
+            logger.warning("Cannot list month dir %s: %s", month_dir, exc)
+            continue
+
+        for item_name in item_entries:
+            item_dir = os.path.join(month_dir, item_name)
+            if not os.path.isdir(item_dir):
+                continue
+
+            text = _find_text_content(item_dir)
+            if text is None:
+                logger.debug("No text content in %s — skipping", item_dir)
+                continue
+
+            metadata = _load_metadata(item_dir)
+            title = metadata.get("title") or item_name
+
+            documents.append(
+                {
+                    "title": title,
+                    "text": text,
+                    "path": item_dir,
+                    "metadata": metadata,
+                }
+            )
+
+    logger.info(
+        "Loaded %d document(s) from media archive at %s",
+        len(documents),
+        media_root,
+    )
+    return documents

--- a/src/mcp_knowledge/semantic.py
+++ b/src/mcp_knowledge/semantic.py
@@ -1,0 +1,158 @@
+"""ChromaDB-backed semantic search index for media archive transcripts."""
+from datetime import datetime, timezone
+
+import chromadb
+
+from .embeddings import EmbeddingProvider
+
+
+class SemanticIndex:
+    """Semantic search index backed by ChromaDB with cosine similarity."""
+
+    COLLECTION_NAME = "crows_nest_media"
+
+    def __init__(self, data_path: str, embedding_provider: EmbeddingProvider) -> None:
+        self._provider = embedding_provider
+        self._client = chromadb.PersistentClient(path=data_path)
+        self._collection = self._client.get_or_create_collection(
+            name=self.COLLECTION_NAME,
+            metadata={"hnsw:space": "cosine"},
+        )
+
+    # ------------------------------------------------------------------
+    # Indexing
+    # ------------------------------------------------------------------
+
+    def index_documents(self, docs: list[dict]) -> int:
+        """Embed and upsert documents into ChromaDB.
+
+        Each doc must have: title, text, path, metadata.
+        metadata may contain: platform, creator, content_type, url.
+        Returns number of documents indexed.
+        """
+        if not docs:
+            return 0
+
+        texts: list[str] = []
+        ids: list[str] = []
+        metadatas: list[dict] = []
+
+        indexed_at = datetime.now(timezone.utc).isoformat()
+
+        for doc in docs:
+            meta = doc.get("metadata", {})
+            creator = meta.get("creator", "")
+            platform = meta.get("platform", "")
+
+            embedding_text = (
+                f"Title: {doc['title']}\n"
+                f"Creator: {creator}\n"
+                f"Platform: {platform}\n"
+                f"{doc['text']}"
+            )
+            texts.append(embedding_text)
+            ids.append(doc["path"])
+            metadatas.append(
+                {
+                    "title": doc["title"],
+                    "path": doc["path"],
+                    "source": "crows-nest",
+                    "indexed_at": indexed_at,
+                    "platform": platform,
+                    "creator": creator,
+                    "content_type": meta.get("content_type", ""),
+                    "url": meta.get("url", ""),
+                }
+            )
+
+        vectors = self._provider.embed(texts)
+
+        self._collection.upsert(
+            ids=ids,
+            embeddings=vectors,
+            documents=[doc["text"] for doc in docs],
+            metadatas=metadatas,
+        )
+        return len(docs)
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    def search(
+        self,
+        query: str,
+        n_results: int = 10,
+        platform: str | None = None,
+    ) -> list[dict]:
+        """Search for documents semantically similar to query.
+
+        Returns list of dicts with: title, snippet, score, similarity,
+        source, search_type, path, metadata.
+        """
+        if self._collection.count() == 0:
+            return []
+
+        where = {"platform": platform} if platform else None
+
+        query_vector = self._provider.embed([query])[0]
+
+        # Clamp n_results to available document count (respecting filter)
+        available = self._collection.count()
+        effective_n = min(n_results, available)
+
+        kwargs: dict = {
+            "query_embeddings": [query_vector],
+            "n_results": effective_n,
+            "include": ["documents", "metadatas", "distances"],
+        }
+        if where:
+            kwargs["where"] = where
+
+        results = self._collection.query(**kwargs)
+
+        output: list[dict] = []
+        ids = results.get("ids", [[]])[0]
+        documents = results.get("documents", [[]])[0]
+        metadatas_list = results.get("metadatas", [[]])[0]
+        distances = results.get("distances", [[]])[0]
+
+        for doc_id, text, meta, distance in zip(ids, documents, metadatas_list, distances):
+            score = 1.0 - distance
+            snippet = (text or "")[:300]
+            output.append(
+                {
+                    "title": meta.get("title", ""),
+                    "snippet": snippet,
+                    "score": score,
+                    "similarity": score,
+                    "source": "crows-nest",
+                    "search_type": "semantic",
+                    "path": meta.get("path", doc_id),
+                    "metadata": {k: v for k, v in meta.items()},
+                }
+            )
+        return output
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    def document_count(self) -> int:
+        """Return number of documents currently in the collection."""
+        return self._collection.count()
+
+    def get_status(self) -> dict:
+        """Return collection name and document count."""
+        return {
+            "collection_name": self.COLLECTION_NAME,
+            "document_count": self.document_count(),
+        }
+
+    def clear(self) -> None:
+        """Delete and recreate the collection, wiping all documents."""
+        self._client.delete_collection(self.COLLECTION_NAME)
+        self._collection = self._client.get_or_create_collection(
+            name=self.COLLECTION_NAME,
+            metadata={"hnsw:space": "cosine"},
+        )

--- a/src/mcp_knowledge/server.py
+++ b/src/mcp_knowledge/server.py
@@ -10,8 +10,11 @@ When forking, you should rarely need to edit this file. Customization points:
 from __future__ import annotations
 
 import json
+import logging
 
 from mcp.server.fastmcp import FastMCP
+
+logger = logging.getLogger("mcp_knowledge.server")
 
 from . import config, knowledge
 
@@ -32,8 +35,8 @@ def _get_semantic_index():
                 data_path=config.SEMANTIC_DATA_DIR,
                 embedding_provider=provider,
             )
-        except ImportError:
-            pass
+        except ImportError as exc:
+            logger.warning("Semantic search unavailable (missing deps): %s", exc)
     return _semantic_index
 
 
@@ -200,21 +203,27 @@ def get_knowledge_document(path: str) -> str:
 
 def main() -> None:
     if config.ENABLE_HTTP_API:
-        import threading
-        def _run_api():
-            import asyncio
-            from .api import start_api_server
-            loop = asyncio.new_event_loop()
-            index = _get_semantic_index()
-            loop.run_until_complete(
-                start_api_server(
-                    semantic_index=index,
-                    host=config.HTTP_HOST,
-                    port=config.HTTP_PORT,
-                )
-            )
-        api_thread = threading.Thread(target=_run_api, daemon=True)
-        api_thread.start()
+        index = _get_semantic_index()
+        if index is None:
+            logger.warning("HTTP API requires semantic deps; skipping API start")
+        else:
+            import threading
+            def _run_api():
+                try:
+                    import asyncio
+                    from .api import start_api_server
+                    loop = asyncio.new_event_loop()
+                    loop.run_until_complete(
+                        start_api_server(
+                            semantic_index=index,
+                            host=config.HTTP_HOST,
+                            port=config.HTTP_PORT,
+                        )
+                    )
+                except Exception:
+                    logger.exception("HTTP API thread failed to start")
+            api_thread = threading.Thread(target=_run_api, daemon=True)
+            api_thread.start()
     mcp.run()
 
 

--- a/src/mcp_knowledge/server.py
+++ b/src/mcp_knowledge/server.py
@@ -17,6 +17,25 @@ from . import config, knowledge
 
 mcp = FastMCP(config.SERVER_NAME)
 
+_semantic_index = None
+
+
+def _get_semantic_index():
+    """Lazy-init the semantic index. Returns None if deps not installed."""
+    global _semantic_index
+    if _semantic_index is None:
+        try:
+            from .embeddings import EmbeddingProvider
+            from .semantic import SemanticIndex
+            provider = EmbeddingProvider(model_name=config.EMBEDDING_MODEL)
+            _semantic_index = SemanticIndex(
+                data_path=config.SEMANTIC_DATA_DIR,
+                embedding_provider=provider,
+            )
+        except ImportError:
+            pass
+    return _semantic_index
+
 
 # ---------------------------------------------------------------------------
 # Tools
@@ -107,6 +126,46 @@ def get_server_info() -> dict:
     }
 
 
+@mcp.tool()
+def semantic_search(
+    query: str,
+    n_results: int = 10,
+    platform: str | None = None,
+) -> list[dict]:
+    """Search media archive transcripts using semantic similarity.
+
+    Args:
+        query: Natural language search query
+        n_results: Max results to return (default 10)
+        platform: Optional filter by platform (YouTube, TikTok, etc.)
+    """
+    index = _get_semantic_index()
+    if index is None:
+        return [{"error": "Semantic search not available — install with pip install -e '.[semantic]'"}]
+    return index.search(query=query, n_results=n_results, platform=platform)
+
+
+@mcp.tool()
+def reindex_media() -> dict:
+    """Reindex the media archive for semantic search."""
+    index = _get_semantic_index()
+    if index is None:
+        return {"error": "Semantic search not available"}
+    from .media_loader import load_media_documents
+    docs = load_media_documents(config.MEDIA_ROOT)
+    count = index.index_documents(docs)
+    return {"indexed": count, "status": "complete"}
+
+
+@mcp.tool()
+def media_status() -> dict:
+    """Get semantic search index status."""
+    index = _get_semantic_index()
+    if index is None:
+        return {"status": "unavailable", "reason": "semantic deps not installed"}
+    return index.get_status()
+
+
 # ---------------------------------------------------------------------------
 # Resources
 # ---------------------------------------------------------------------------
@@ -140,6 +199,22 @@ def get_knowledge_document(path: str) -> str:
 
 
 def main() -> None:
+    if config.ENABLE_HTTP_API:
+        import threading
+        def _run_api():
+            import asyncio
+            from .api import start_api_server
+            loop = asyncio.new_event_loop()
+            index = _get_semantic_index()
+            loop.run_until_complete(
+                start_api_server(
+                    semantic_index=index,
+                    host=config.HTTP_HOST,
+                    port=config.HTTP_PORT,
+                )
+            )
+        api_thread = threading.Thread(target=_run_api, daemon=True)
+        api_thread.start()
     mcp.run()
 
 

--- a/tests/pipeline/test_archiver_credentials.py
+++ b/tests/pipeline/test_archiver_credentials.py
@@ -1,0 +1,70 @@
+"""
+Tests for R2 credential wiring in archiver.py.
+
+Verifies that get_r2_client() reads credentials from Keychain (via get_secret)
+rather than directly from environment variables.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../pipeline"))
+
+import archiver
+
+MOCK_SECRETS = {
+    "R2_ACCESS_KEY_ID": "test-access-key",
+    "R2_SECRET_ACCESS_KEY": "test-secret-key",
+    "R2_ENDPOINT_URL": "https://acct.r2.cloudflarestorage.com",
+}
+
+
+def test_get_r2_client_reads_from_keychain():
+    """R2 client should read credentials from Keychain secrets."""
+    mock_boto3 = MagicMock()
+
+    with patch.object(archiver, "get_secret", side_effect=lambda k, **kw: MOCK_SECRETS.get(k)):
+        with patch.object(archiver, "boto3", mock_boto3):
+            archiver.get_r2_client()
+
+            mock_boto3.client.assert_called_once()
+            call_kwargs = mock_boto3.client.call_args
+            assert call_kwargs[1]["endpoint_url"] == "https://acct.r2.cloudflarestorage.com"
+            assert call_kwargs[1]["aws_access_key_id"] == "test-access-key"
+            assert call_kwargs[1]["aws_secret_access_key"] == "test-secret-key"
+
+
+def test_get_r2_client_uses_s3_service():
+    """boto3.client should be called with 's3' as the service name."""
+    mock_boto3 = MagicMock()
+
+    with patch.object(archiver, "get_secret", side_effect=lambda k, **kw: MOCK_SECRETS.get(k)):
+        with patch.object(archiver, "boto3", mock_boto3):
+            archiver.get_r2_client()
+
+            args = mock_boto3.client.call_args[0]
+            assert args[0] == "s3"
+
+
+def test_upload_to_r2_returns_true_on_success():
+    """upload_to_r2 should return True when boto3 upload_file succeeds."""
+    mock_client = MagicMock()
+    mock_client.upload_file.return_value = None  # upload_file returns None on success
+
+    with patch.object(archiver, "get_secret", side_effect=lambda k, **kw: MOCK_SECRETS.get(k)):
+        with patch.object(archiver, "get_r2_client", return_value=mock_client):
+            result = archiver.upload_to_r2("/tmp/some-archive.tar.gz", "2025/06/some-archive.tar.gz")
+            assert result is True
+            mock_client.upload_file.assert_called_once()
+
+
+def test_upload_to_r2_returns_false_on_exception():
+    """upload_to_r2 should return False when boto3 raises an exception."""
+    mock_client = MagicMock()
+    mock_client.upload_file.side_effect = RuntimeError("connection refused")
+
+    with patch.object(archiver, "get_secret", side_effect=lambda k, **kw: MOCK_SECRETS.get(k)):
+        with patch.object(archiver, "get_r2_client", return_value=mock_client):
+            result = archiver.upload_to_r2("/tmp/some-archive.tar.gz", "2025/06/some-archive.tar.gz")
+            assert result is False

--- a/tests/pipeline/test_media_relocation.py
+++ b/tests/pipeline/test_media_relocation.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../pipeline"))
+
+
+def test_media_root_defaults_to_crows_nest_home_media(monkeypatch):
+    """MEDIA_ROOT default must be {CROWS_NEST_HOME}/media, not ~/Media/crows-nest."""
+    # Remove overrides so we exercise the defaults
+    monkeypatch.delenv("MEDIA_ROOT", raising=False)
+    monkeypatch.delenv("CROWS_NEST_HOME", raising=False)
+
+    # Re-import config with clean env
+    import importlib
+    import pipeline.config as config_mod
+    importlib.reload(config_mod)
+
+    expected_home = os.path.expanduser("~/Developer/second-brain/crows-nest")
+    expected_media = os.path.join(expected_home, "media")
+
+    assert config_mod.MEDIA_ROOT == expected_media, (
+        f"Expected MEDIA_ROOT={expected_media!r}, got {config_mod.MEDIA_ROOT!r}"
+    )
+
+
+def test_media_root_env_override(monkeypatch):
+    """MEDIA_ROOT env var must override the default."""
+    monkeypatch.setenv("MEDIA_ROOT", "/custom/media/path")
+
+    import importlib
+    import pipeline.config as config_mod
+    importlib.reload(config_mod)
+
+    assert config_mod.MEDIA_ROOT == "/custom/media/path"
+
+
+def test_media_root_tracks_crows_nest_home(monkeypatch):
+    """When CROWS_NEST_HOME is overridden, MEDIA_ROOT default must follow it."""
+    monkeypatch.setenv("CROWS_NEST_HOME", "/opt/crows-nest")
+    monkeypatch.delenv("MEDIA_ROOT", raising=False)
+
+    import importlib
+    import pipeline.config as config_mod
+    importlib.reload(config_mod)
+
+    assert config_mod.MEDIA_ROOT == "/opt/crows-nest/media"

--- a/tests/pipeline/test_video_path.py
+++ b/tests/pipeline/test_video_path.py
@@ -1,10 +1,13 @@
 import sys
 import os
 import sqlite3
+import inspect
+from unittest import mock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../pipeline"))
 
 import db
+import processor
 
 
 def test_video_path_column_exists(tmp_path):
@@ -47,3 +50,39 @@ def test_update_status_sets_video_path(tmp_path):
 
     assert row["status"] == "transcribed"
     assert row["video_path"] == "/media/abc123/video.mp4"
+
+
+def test_process_video_function_signature():
+    """Verify process_video has the expected parameters."""
+    sig = inspect.signature(processor.process_video)
+    params = list(sig.parameters.keys())
+    assert "link_id" in params
+    assert "url" in params
+    assert "content_type" in params
+    assert "media_dir" in params
+    assert "context" in params
+    assert "db_path" in params
+
+
+def test_video_download_format_string_in_source():
+    """Verify the yt-dlp format string for video download is present in processor source."""
+    source = inspect.getsource(processor.process_video)
+    # The video download should use the mp4-preferred format selector
+    assert "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best" in source
+    # Should use --merge-output-format mp4
+    assert "--merge-output-format" in source
+    # Should extract audio via ffmpeg (not just yt-dlp --extract-audio)
+    assert "ffmpeg" in source
+    assert "-vn" in source
+    assert "-acodec" in source
+
+
+def test_video_download_preserves_fallback_logic():
+    """Verify the audio-only fallback is still present in processor source."""
+    source = inspect.getsource(processor.process_video)
+    # Audio-only fallback should still exist
+    assert "--extract-audio" in source
+    assert "--audio-format" in source
+    # RSS fallback should still exist
+    assert "rss_audio_url" in source
+    assert "RSS audio fallback" in source

--- a/tests/pipeline/test_video_path.py
+++ b/tests/pipeline/test_video_path.py
@@ -1,0 +1,49 @@
+import sys
+import os
+import sqlite3
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../pipeline"))
+
+import db
+
+
+def test_video_path_column_exists(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    db.init_db(db_path)
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.execute("PRAGMA table_info(links)")
+    columns = {row[1] for row in cursor.fetchall()}
+    conn.close()
+
+    assert "video_path" in columns
+
+
+def test_update_status_sets_video_path(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    db.init_db(db_path)
+
+    link_id = db.add_link(
+        url="https://example.com/video",
+        source_type="signal",
+        sender="+15551234567",
+        context="test video",
+        content_type="video",
+        db_path=db_path,
+    )
+
+    db.update_status(
+        link_id=link_id,
+        status="transcribed",
+        video_path="/media/abc123/video.mp4",
+        db_path=db_path,
+    )
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute("SELECT status, video_path FROM links WHERE id = ?", (link_id,))
+    row = cursor.fetchone()
+    conn.close()
+
+    assert row["status"] == "transcribed"
+    assert row["video_path"] == "/media/abc123/video.mp4"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,103 @@
+"""Tests for the HTTP API layer."""
+from unittest.mock import MagicMock
+
+from starlette.testclient import TestClient
+
+from mcp_knowledge.api import create_api
+
+
+def _make_test_client():
+    mock_semantic = MagicMock()
+    mock_semantic.search.return_value = [
+        {
+            "title": "Test",
+            "snippet": "...",
+            "score": 0.85,
+            "similarity": 0.85,
+            "source": "crows-nest",
+            "search_type": "semantic",
+            "path": "/test",
+            "metadata": {},
+        }
+    ]
+    mock_semantic.get_status.return_value = {
+        "document_count": 42,
+        "collection_name": "test",
+    }
+
+    app = create_api(semantic_index=mock_semantic)
+    return TestClient(app), mock_semantic
+
+
+def test_search_endpoint():
+    client, mock = _make_test_client()
+    r = client.post("/search", json={"query": "test"})
+    assert r.status_code == 200
+    assert len(r.json()["results"]) == 1
+    mock.search.assert_called_once()
+
+
+def test_search_requires_query():
+    client, _ = _make_test_client()
+    r = client.post("/search", json={})
+    assert r.status_code == 400
+
+
+def test_search_passes_platform_and_n_results():
+    client, mock = _make_test_client()
+    r = client.post("/search", json={"query": "test", "n_results": 5, "platform": "youtube"})
+    assert r.status_code == 200
+    mock.search.assert_called_once_with(query="test", n_results=5, platform="youtube")
+
+
+def test_search_with_knowledge_base():
+    mock_semantic = MagicMock()
+    mock_semantic.search.return_value = [{"title": "Semantic", "source": "crows-nest"}]
+    mock_semantic.get_status.return_value = {}
+
+    mock_kb = MagicMock()
+    mock_kb.search_knowledge.return_value = [{"title": "Keyword", "source": "knowledge"}]
+
+    app = create_api(semantic_index=mock_semantic, knowledge_base=mock_kb)
+    client = TestClient(app)
+
+    r = client.post("/search", json={"query": "test"})
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert len(results) == 2
+    titles = {item["title"] for item in results}
+    assert titles == {"Semantic", "Keyword"}
+    mock_kb.search_knowledge.assert_called_once_with(query="test", max_results=10)
+
+
+def test_health_endpoint():
+    client, _ = _make_test_client()
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+    assert r.json()["service"] == "crows-nest"
+
+
+def test_status_endpoint():
+    client, _ = _make_test_client()
+    r = client.get("/status")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["semantic"]["document_count"] == 42
+    assert data["service"] == "crows-nest"
+
+
+def test_reindex_not_implemented():
+    client, _ = _make_test_client()
+    r = client.post("/reindex")
+    assert r.status_code == 501
+
+
+def test_search_empty_results():
+    mock_semantic = MagicMock()
+    mock_semantic.search.return_value = []
+    app = create_api(semantic_index=mock_semantic)
+    client = TestClient(app)
+    r = client.post("/search", json={"query": "nothing"})
+    assert r.status_code == 200
+    assert r.json()["results"] == []

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,18 @@
+from mcp_knowledge.embeddings import EmbeddingProvider
+
+
+def test_embed_returns_vectors():
+    """EmbeddingProvider.embed should return float vectors."""
+    provider = EmbeddingProvider()
+    vectors = provider.embed(["hello world", "test query"])
+    assert len(vectors) == 2
+    assert len(vectors[0]) > 0
+    assert all(isinstance(v, float) for v in vectors[0])
+
+
+def test_embed_lazy_loads_model():
+    """Model should not load until first embed call."""
+    provider = EmbeddingProvider()
+    assert provider._model is None
+    provider.embed(["trigger load"])
+    assert provider._model is not None

--- a/tests/test_media_loader.py
+++ b/tests/test_media_loader.py
@@ -1,0 +1,214 @@
+"""Tests for the mcp_knowledge.media_loader module."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from mcp_knowledge.media_loader import load_media_documents
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_media_item(
+    root: Path,
+    month: str,
+    dirname: str,
+    *,
+    transcript: str | None = None,
+    transcript_filename: str | None = None,
+    page_txt: str | None = None,
+    article_md: str | None = None,
+    metadata: dict | None = None,
+) -> Path:
+    """Create a fake media item directory tree."""
+    item_dir = root / month / dirname
+    item_dir.mkdir(parents=True, exist_ok=True)
+
+    if metadata is not None:
+        (item_dir / "metadata.json").write_text(
+            json.dumps(metadata), encoding="utf-8"
+        )
+
+    if page_txt is not None:
+        (item_dir / "page.txt").write_text(page_txt, encoding="utf-8")
+
+    if article_md is not None:
+        (item_dir / "article.md").write_text(article_md, encoding="utf-8")
+
+    if transcript is not None:
+        fname = transcript_filename or f"{dirname}.txt"
+        (item_dir / fname).write_text(transcript, encoding="utf-8")
+
+    return item_dir
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+class TestLoadMediaDocuments:
+    def test_finds_transcripts(self, tmp_path: Path) -> None:
+        """Item with transcript + metadata.json is loaded with correct fields."""
+        metadata = {
+            "title": "My Great Video",
+            "creator": "Some Creator",
+            "platform": "youtube",
+            "url": "https://youtube.com/watch?v=abc",
+        }
+        item_dir = make_media_item(
+            tmp_path,
+            "2026-03",
+            "my-great-video",
+            transcript="Hello world transcript content.",
+            transcript_filename="my-great-video.txt",
+            metadata=metadata,
+        )
+
+        docs = load_media_documents(str(tmp_path))
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["title"] == "My Great Video"
+        assert doc["text"] == "Hello world transcript content."
+        assert doc["path"] == str(item_dir)
+        assert doc["metadata"]["platform"] == "youtube"
+        assert doc["metadata"]["url"] == "https://youtube.com/watch?v=abc"
+
+    def test_skips_items_without_text_content(self, tmp_path: Path) -> None:
+        """Item with only metadata.json and no text file is skipped."""
+        make_media_item(
+            tmp_path,
+            "2026-03",
+            "metadata-only",
+            metadata={"title": "No Text Here"},
+        )
+
+        docs = load_media_documents(str(tmp_path))
+
+        assert docs == []
+
+    def test_includes_web_pages_via_page_txt(self, tmp_path: Path) -> None:
+        """Item with page.txt is loaded as a document."""
+        metadata = {
+            "title": "Some Article",
+            "platform": "web_page",
+            "url": "https://example.com/article",
+        }
+        item_dir = make_media_item(
+            tmp_path,
+            "2026-02",
+            "some-article",
+            page_txt="Article body content here.",
+            metadata=metadata,
+        )
+
+        docs = load_media_documents(str(tmp_path))
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["title"] == "Some Article"
+        assert doc["text"] == "Article body content here."
+        assert doc["path"] == str(item_dir)
+
+    def test_page_txt_takes_priority_over_transcript(self, tmp_path: Path) -> None:
+        """When both page.txt and a transcript exist, page.txt is preferred."""
+        make_media_item(
+            tmp_path,
+            "2026-03",
+            "mixed-item",
+            page_txt="Page content.",
+            transcript="Transcript content.",
+            transcript_filename="mixed-item.txt",
+            metadata={"title": "Mixed Item"},
+        )
+
+        docs = load_media_documents(str(tmp_path))
+
+        assert len(docs) == 1
+        assert docs[0]["text"] == "Page content."
+
+    def test_article_md_takes_priority_over_transcript(self, tmp_path: Path) -> None:
+        """When both article.md and a transcript exist, article.md is preferred."""
+        make_media_item(
+            tmp_path,
+            "2026-03",
+            "md-item",
+            article_md="Article markdown content.",
+            transcript="Transcript content.",
+            transcript_filename="md-item.txt",
+            metadata={"title": "MD Item"},
+        )
+
+        docs = load_media_documents(str(tmp_path))
+
+        assert len(docs) == 1
+        assert docs[0]["text"] == "Article markdown content."
+
+    def test_falls_back_to_dirname_when_no_metadata(self, tmp_path: Path) -> None:
+        """When metadata.json is absent, title falls back to the directory name."""
+        item_dir = make_media_item(
+            tmp_path,
+            "2026-03",
+            "no-metadata-item",
+            transcript="Some transcript.",
+            transcript_filename="no-metadata-item.txt",
+        )
+
+        docs = load_media_documents(str(tmp_path))
+
+        assert len(docs) == 1
+        assert docs[0]["title"] == "no-metadata-item"
+        assert docs[0]["metadata"] == {}
+
+    def test_loads_multiple_items_across_months(self, tmp_path: Path) -> None:
+        """Documents are collected from multiple month directories."""
+        make_media_item(
+            tmp_path,
+            "2026-01",
+            "jan-item",
+            transcript="January content.",
+            transcript_filename="jan-item.txt",
+            metadata={"title": "January Item"},
+        )
+        make_media_item(
+            tmp_path,
+            "2026-02",
+            "feb-item",
+            page_txt="February page.",
+            metadata={"title": "February Item"},
+        )
+
+        docs = load_media_documents(str(tmp_path))
+
+        assert len(docs) == 2
+        titles = {d["title"] for d in docs}
+        assert titles == {"January Item", "February Item"}
+
+    def test_skips_media_files_not_text(self, tmp_path: Path) -> None:
+        """Media files (.m4a, .mp4) in the item dir do not cause errors or false loads."""
+        item_dir = tmp_path / "2026-03" / "video-with-media"
+        item_dir.mkdir(parents=True, exist_ok=True)
+        (item_dir / "video.m4a").write_bytes(b"\x00\x01\x02")
+        (item_dir / "video.mp4").write_bytes(b"\x00\x01\x02")
+        # No text content — should be skipped
+        docs = load_media_documents(str(tmp_path))
+        assert docs == []
+
+    def test_returns_empty_list_for_empty_media_root(self, tmp_path: Path) -> None:
+        """Empty media root returns empty list without error."""
+        docs = load_media_documents(str(tmp_path))
+        assert docs == []
+
+    def test_returns_empty_list_for_nonexistent_media_root(self) -> None:
+        """Nonexistent media root returns empty list without raising."""
+        docs = load_media_documents("/nonexistent/path/that/does/not/exist")
+        assert docs == []

--- a/tests/test_semantic.py
+++ b/tests/test_semantic.py
@@ -1,0 +1,140 @@
+"""Tests for SemanticIndex: ChromaDB-backed semantic search."""
+import tempfile
+
+import pytest
+
+from mcp_knowledge.embeddings import EmbeddingProvider
+from mcp_knowledge.semantic import SemanticIndex
+
+
+@pytest.fixture(scope="module")
+def provider():
+    return EmbeddingProvider()
+
+
+def make_docs():
+    return [
+        {
+            "title": "Python Asyncio Deep Dive",
+            "text": "Asyncio is a Python library for writing concurrent code using async and await syntax. It enables cooperative multitasking and is ideal for IO-bound workloads.",
+            "path": "youtube/asyncio-deep-dive",
+            "metadata": {
+                "platform": "youtube",
+                "creator": "ArjanCodes",
+                "content_type": "video",
+                "url": "https://youtube.com/watch?v=abc123",
+            },
+        },
+        {
+            "title": "Introduction to Sourdough Baking",
+            "text": "Sourdough bread relies on wild yeast fermentation. A healthy starter produces carbon dioxide bubbles which leaven the dough.",
+            "path": "youtube/sourdough-baking",
+            "metadata": {
+                "platform": "youtube",
+                "creator": "BreadBaker",
+                "content_type": "video",
+                "url": "https://youtube.com/watch?v=xyz789",
+            },
+        },
+    ]
+
+
+def test_index_and_search(provider):
+    """Index two documents; searching for async programming should rank the Python doc first."""
+    with tempfile.TemporaryDirectory() as tmp:
+        idx = SemanticIndex(tmp, provider)
+        count = idx.index_documents(make_docs())
+        assert count == 2
+
+        results = idx.search("concurrent programming with async await", n_results=2)
+        assert len(results) > 0
+        assert results[0]["path"] == "youtube/asyncio-deep-dive"
+
+        # Result fields present
+        first = results[0]
+        assert "title" in first
+        assert "snippet" in first
+        assert "score" in first
+        assert "similarity" in first
+        assert first["source"] == "crows-nest"
+        assert first["search_type"] == "semantic"
+        assert len(first["snippet"]) <= 300
+
+
+def test_search_empty_index(provider):
+    """Searching an empty collection should return an empty list, not raise."""
+    with tempfile.TemporaryDirectory() as tmp:
+        idx = SemanticIndex(tmp, provider)
+        results = idx.search("anything at all")
+        assert results == []
+
+
+def test_reindex_replaces_documents(provider):
+    """Re-indexing the same paths with different content should replace, not duplicate."""
+    with tempfile.TemporaryDirectory() as tmp:
+        idx = SemanticIndex(tmp, provider)
+        idx.index_documents(make_docs())
+        assert idx.document_count() == 2
+
+        # Re-index with updated docs (same paths, different text)
+        updated = [
+            {
+                "title": "Python Asyncio Updated",
+                "text": "Updated content about event loops.",
+                "path": "youtube/asyncio-deep-dive",
+                "metadata": {
+                    "platform": "youtube",
+                    "creator": "ArjanCodes",
+                    "content_type": "video",
+                    "url": "https://youtube.com/watch?v=abc123",
+                },
+            }
+        ]
+        idx.index_documents(updated)
+        # Should still be 2, not 3 — upsert replaced the existing doc
+        assert idx.document_count() == 2
+
+
+def test_get_status(provider):
+    """Status dict should include collection_name and correct document_count."""
+    with tempfile.TemporaryDirectory() as tmp:
+        idx = SemanticIndex(tmp, provider)
+        idx.index_documents(make_docs())
+
+        status = idx.get_status()
+        assert status["collection_name"] == SemanticIndex.COLLECTION_NAME
+        assert status["document_count"] == 2
+
+
+def test_platform_filter(provider):
+    """Platform filter should narrow results to matching platform only."""
+    docs = make_docs() + [
+        {
+            "title": "Async Podcast Episode",
+            "text": "A podcast discussing Python's async ecosystem, event loops, and concurrency patterns.",
+            "path": "podcast/async-episode",
+            "metadata": {
+                "platform": "podcast",
+                "creator": "PythonPodcast",
+                "content_type": "audio",
+                "url": "https://podcast.example.com/ep1",
+            },
+        }
+    ]
+    with tempfile.TemporaryDirectory() as tmp:
+        idx = SemanticIndex(tmp, provider)
+        idx.index_documents(docs)
+
+        results = idx.search("async programming", n_results=5, platform="podcast")
+        assert all(r["metadata"].get("platform") == "podcast" for r in results)
+
+
+def test_clear_resets_collection(provider):
+    """After clear(), document_count should be 0."""
+    with tempfile.TemporaryDirectory() as tmp:
+        idx = SemanticIndex(tmp, provider)
+        idx.index_documents(make_docs())
+        assert idx.document_count() == 2
+
+        idx.clear()
+        assert idx.document_count() == 0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -49,10 +49,13 @@ def knowledge_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 class TestToolRegistration:
-    def test_four_tools_registered(self) -> None:
+    def test_seven_tools_registered(self) -> None:
         tools = asyncio.run(mcp.list_tools())
         tool_names = {t.name for t in tools}
-        expected = {"search_knowledge", "list_topics", "get_document", "get_server_info"}
+        expected = {
+            "search_knowledge", "list_topics", "get_document", "get_server_info",
+            "semantic_search", "reindex_media", "media_status",
+        }
         assert expected == tool_names, (
             f"Expected tools {expected}, got {tool_names}"
         )


### PR DESCRIPTION
## Summary

Comprehensive refactor addressing issues #18, #19, #20, #21:

- **Media store relocation** (#18): Move `MEDIA_ROOT` default from `~/Media/crows-nest/` into `crows-nest/media/` (gitignored). Includes path migration script for existing SQLite records.
- **Video preservation** (#19): Processor now downloads full video (mp4) first, extracts audio via ffmpeg for Whisper. Falls back to audio-only if video download fails. Includes backfill script for existing audio-only items.
- **R2 archival credentials** (#20): Replace `wrangler` CLI with boto3 S3-compatible client. Credentials read from macOS Keychain (`developer.workspace.R2_*`).
- **Semantic search + HTTP API** (#21): ChromaDB + fastembed semantic search over media archive transcripts. 3 new MCP tools (`semantic_search`, `reindex_media`, `media_status`). Optional Starlette HTTP API on port 27185.

## Stats

- 15 commits, 23 files changed, +1727 / -87 lines
- 148 tests passing (38 new, 110 baseline)
- Semantic dependencies are optional — server gracefully degrades without them

## Post-merge manual steps

1. Migrate existing media: `mv ~/Media/crows-nest/* media/` then `python pipeline/migrate_media_paths.py`
2. Add R2 credentials to Keychain (see CLAUDE.md)
3. Video backfill: `python pipeline/backfill_video.py --dry-run` then `--limit 5`
4. Build semantic index: call `reindex_media` MCP tool

## Test plan

- [x] 148 tests passing (full suite)
- [ ] Migrate existing media and run path migration script
- [ ] Run backfill script with `--dry-run` to verify candidates
- [ ] Add R2 credentials and test archiver end-to-end
- [ ] Enable HTTP API (`CROWS_NEST_HTTP_API=true`) and test endpoints
- [ ] Call `reindex_media` and verify `semantic_search` returns results

Closes #18, #19, #20, #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)