### PR TITLE
fix: backfill script derives media_dir from download_path parent

### DIFF
--- a/pipeline/backfill_video.py
+++ b/pipeline/backfill_video.py
@@ -150,7 +150,10 @@ def main() -> None:
     for i, row in enumerate(candidates, 1):
         link_id = row["id"]
         url = row["url"]
+        # download_path may be a file path (e.g., .../title.m4a) — use its parent dir
         media_dir = row["download_path"]
+        if media_dir and not os.path.isdir(media_dir):
+            media_dir = os.path.dirname(media_dir)
 
         print(f"[{i}/{len(candidates)}] {url}... ", end="", flush=True)
 


### PR DESCRIPTION
## Summary

- `download_path` in the DB stores a file path (e.g., `.../title.m4a`), not a directory
- The backfill script used it directly as `media_dir`, causing all downloads to fail
- Fix: use `os.path.dirname()` to get the parent directory

Tested: 4/5 TikToks downloaded successfully, 1 podcast correctly failed (no video format available).