### PR TITLE
fix: set server name and description

### DIFF
--- a/src/mcp_knowledge/config.py
+++ b/src/mcp_knowledge/config.py
@@ -8,8 +8,8 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 
 # FORK: Change these to describe your specific knowledge domain.
-SERVER_NAME = "my-knowledge-server"
-SERVER_DESCRIPTION = "Expert knowledge about [your domain]"
+SERVER_NAME = "crows-nest"
+SERVER_DESCRIPTION = "MCP server for database of preserved content from various internet sources, including video transcripts and RSS feeds"
 
 # ---------------------------------------------------------------------------
 # Paths


### PR DESCRIPTION
## Summary
- Replace placeholder `my-knowledge-server` / `Expert knowledge about [your domain]` with actual crows-nest identity
- Discovered during morning briefing when `get_server_info` returned generic metadata

## Test plan
- [ ] Restart MCP server, verify `get_server_info` returns "crows-nest" name

🤖 Generated with [Claude Code](https://claude.com/claude-code)