### PR TITLE
feat: detect signal-cli registration failures in health check

### DIFF
--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -49,6 +49,7 @@ PIPELINE_DIR = os.path.join(CROWS_NEST_HOME, "pipeline")
 
 DB_PATH = os.path.join(DATA_DIR, "crows-nest.db")
 MESSAGE_LOG = os.path.join(LOG_DIR, "signal-messages.log")
+SIGNAL_HEALTH_FILE = os.path.join(LOG_DIR, "signal-health.json")
 WHISPER_SCRIPT = os.path.join(SCRIPTS_DIR, "whisper-transcribe.sh")
 
 OBSIDIAN_CLIPPINGS = os.path.join(OBSIDIAN_VAULT, "2 - AREAS", "CLIPPINGS - Need Sorting")

--- a/pipeline/signal_listener.py
+++ b/pipeline/signal_listener.py
@@ -12,7 +12,7 @@ import sqlite3
 import subprocess
 from datetime import datetime, timezone
 
-from config import MESSAGE_LOG
+from config import MESSAGE_LOG, SIGNAL_HEALTH_FILE
 from content_types import classify_url
 from db import init_db, add_link, get_connection
 from keychain_secrets import get_secret
@@ -190,7 +190,7 @@ def _batch_image_messages(messages: list[dict]) -> tuple[list[dict], list[dict]]
     return image_batches, non_image_messages
 
 
-def receive_messages() -> list[dict]:
+def receive_messages() -> list[dict] | None:
     """Invoke signal-cli in JSON mode and return parsed messages.
 
     Calls `signal-cli -u {SIGNAL_USER} receive --timeout {RECEIVE_TIMEOUT} --json`.
@@ -200,6 +200,7 @@ def receive_messages() -> list[dict]:
         List of dicts with keys "sender_id", "sender_name", "message",
         "timestamp", "group_name", "attachments".
         Returns an empty list on any subprocess error.
+        Returns None on fatal errors (e.g. account not registered).
     """
     cmd = [
         SIGNAL_CLI,
@@ -215,6 +216,18 @@ def receive_messages() -> list[dict]:
             text=True,
             timeout=RECEIVE_TIMEOUT + 5,
         )
+        stderr = result.stderr.strip() if result.stderr else ""
+        if result.returncode != 0 and stderr:
+            if "not registered" in stderr.lower():
+                logger.critical(
+                    "signal-cli: account is NOT REGISTERED. "
+                    "Messages cannot be sent or received. "
+                    "Re-register with: signal-cli -u %s register && signal-cli -u %s verify CODE",
+                    SIGNAL_USER, SIGNAL_USER,
+                )
+                return None
+            logger.error("signal-cli exited %d: %s", result.returncode, stderr)
+            return None
         return _parse_json_output(result.stdout)
     except subprocess.TimeoutExpired as exc:
         # signal-cli writes messages to stdout as they arrive, so even
@@ -265,6 +278,22 @@ def _log_message(sender: str, body: str, group: str = "") -> None:
         logger.warning("Could not write to message log: %s", exc)
 
 
+def _write_health(status: str, error: str = "", message: str = "") -> None:
+    """Write a machine-readable health status file for the signal listener."""
+    ts = datetime.now(timezone.utc).isoformat()
+    payload = {"status": status, "timestamp": ts}
+    if error:
+        payload["error"] = error
+    if message:
+        payload["message"] = message
+    try:
+        os.makedirs(os.path.dirname(SIGNAL_HEALTH_FILE), exist_ok=True)
+        with open(SIGNAL_HEALTH_FILE, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+    except OSError as exc:
+        logger.warning("Could not write health file: %s", exc)
+
+
 def run(db_path: str) -> None:
     """Main entry point: receive messages, extract URLs, store, confirm.
 
@@ -280,10 +309,17 @@ def run(db_path: str) -> None:
     """
     if not SIGNAL_USER:
         logger.error("SIGNAL_USER not set (check Keychain or env var) — cannot receive messages")
+        _write_health("error", "no_signal_user", "SIGNAL_USER not configured")
         return
 
     init_db(db_path)
     messages = receive_messages()
+
+    if messages is None:
+        _write_health("error", "not_registered", f"signal-cli account {SIGNAL_USER} is not registered")
+        return
+
+    _write_health("ok")
 
     image_batches, non_image_messages = _batch_image_messages(messages)
 

--- a/pipeline/status.py
+++ b/pipeline/status.py
@@ -14,7 +14,9 @@ from datetime import datetime, timezone
 # Allow running directly from any working directory
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from config import LOG_DIR
+import json
+
+from config import LOG_DIR, SIGNAL_HEALTH_FILE
 from db import DB_PATH, get_connection, init_db
 
 
@@ -183,6 +185,41 @@ def check_log_freshness() -> list[str]:
     return problems
 
 
+def check_signal_health() -> list[str]:
+    """Check signal-cli health from the listener's health status file."""
+    problems = []
+    if not os.path.exists(SIGNAL_HEALTH_FILE):
+        problems.append("signal-cli: health file missing (listener may not have run yet)")
+        return problems
+    try:
+        with open(SIGNAL_HEALTH_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        problems.append(f"signal-cli: could not read health file ({exc})")
+        return problems
+
+    status = data.get("status")
+    if status == "error":
+        error_type = data.get("error", "unknown")
+        message = data.get("message", "")
+        problems.append(f"signal-cli: {error_type} — {message}")
+    elif status == "ok":
+        ts_str = data.get("timestamp", "")
+        if ts_str:
+            try:
+                last_ok = datetime.fromisoformat(ts_str)
+                age_minutes = (datetime.now(timezone.utc) - last_ok).total_seconds() / 60
+                if age_minutes > 15:
+                    hours = int(age_minutes // 60)
+                    mins = int(age_minutes % 60)
+                    problems.append(
+                        f"signal-cli: last OK {hours}h{mins}m ago (threshold 15m)"
+                    )
+            except ValueError:
+                pass
+    return problems
+
+
 def print_health() -> bool:
     """Run all health checks, print results, return True if healthy."""
     all_ok = True
@@ -211,6 +248,17 @@ def print_health() -> bool:
             print(f"    WARN  {p}")
     else:
         print("  Log freshness:    OK (all logs recently updated)")
+
+    print()
+
+    signal_problems = check_signal_health()
+    if signal_problems:
+        all_ok = False
+        print("  Signal listener check:")
+        for p in signal_problems:
+            print(f"    FAIL  {p}")
+    else:
+        print("  Signal listener:  OK (signal-cli healthy)")
 
     print()
     if all_ok:

--- a/tests/pipeline/test_signal_listener.py
+++ b/tests/pipeline/test_signal_listener.py
@@ -3,6 +3,7 @@
 import json
 import sys
 import os
+from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../pipeline"))
 
@@ -10,6 +11,8 @@ from signal_listener import (
     parse_signal_message,
     _parse_json_output,
     _batch_image_messages,
+    receive_messages,
+    _write_health,
 )
 
 
@@ -238,3 +241,68 @@ def test_mixed_messages_separated():
     assert len(batches) == 1
     assert len(non_image) == 1
     assert "https://example.com" in non_image[0]["message"]
+
+
+# --- receive_messages: fatal error detection ---
+
+@patch("signal_listener.subprocess.run")
+def test_receive_returns_none_when_not_registered(mock_run):
+    """signal-cli 'not registered' error returns None (fatal)."""
+    mock_run.return_value = MagicMock(
+        returncode=1,
+        stdout="",
+        stderr="User +16124706803 is not registered.",
+    )
+    result = receive_messages()
+    assert result is None
+
+
+@patch("signal_listener.subprocess.run")
+def test_receive_returns_none_on_other_fatal_error(mock_run):
+    """Non-zero exit with stderr returns None."""
+    mock_run.return_value = MagicMock(
+        returncode=1,
+        stdout="",
+        stderr="Some other fatal error from signal-cli",
+    )
+    result = receive_messages()
+    assert result is None
+
+
+@patch("signal_listener.subprocess.run")
+def test_receive_returns_list_on_success(mock_run):
+    """Successful signal-cli invocation returns a list (possibly empty)."""
+    mock_run.return_value = MagicMock(
+        returncode=0,
+        stdout="",
+        stderr="",
+    )
+    result = receive_messages()
+    assert result == []
+
+
+# --- _write_health ---
+
+def test_write_health_creates_file(tmp_path):
+    """Health file is written with correct structure."""
+    health_file = str(tmp_path / "signal-health.json")
+    with patch("signal_listener.SIGNAL_HEALTH_FILE", health_file):
+        _write_health("error", "not_registered", "account not registered")
+
+    with open(health_file) as f:
+        data = json.load(f)
+    assert data["status"] == "error"
+    assert data["error"] == "not_registered"
+    assert "timestamp" in data
+
+
+def test_write_health_ok(tmp_path):
+    """OK health status has no error fields."""
+    health_file = str(tmp_path / "signal-health.json")
+    with patch("signal_listener.SIGNAL_HEALTH_FILE", health_file):
+        _write_health("ok")
+
+    with open(health_file) as f:
+        data = json.load(f)
+    assert data["status"] == "ok"
+    assert "error" not in data


### PR DESCRIPTION
## Summary
- `receive_messages()` now checks signal-cli's stderr and return code — returns `None` on fatal errors like "not registered" instead of silently returning an empty list
- `run()` writes `signal-health.json` to the logs directory on every invocation (ok/error status with timestamps)
- `status.py --health` reads the health file and reports signal-cli problems (unregistered, stale, missing config)
- 5 new tests covering error detection and health file writing (19 total, all passing)

## Context
The Signal account used by the pipeline became unregistered, but the listener kept running silently every 5 minutes with no indication anything was wrong. This change makes registration failures loud and visible.

## Test plan
- [x] All 19 signal listener tests pass
- [x] Existing 14 tests unaffected
- [ ] After re-registering signal-cli, verify `signal-health.json` shows `"status": "ok"`
- [ ] Run `status.py --health` to confirm signal listener check appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)