### PR TITLE
fix: correct R2 bucket name to crows-nest-media-archive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Two systems in one repo: an **MCP knowledge server** and a **Signal-to-Obsidian 
 1. **Listener** (`pipeline/signal_listener.py`) — polls signal-cli every 5 min, extracts URLs and image batches, saves to SQLite
 2. **Processor** (`pipeline/processor.py`) — downloads media, transcribes audio/video with Whisper, scrapes web pages
 3. **Summarizer** (`pipeline/summarizer.py`) — calls Claude Haiku via OpenRouter for structured analysis, writes Obsidian notes to `0 - INBOX/Clippings/`
-4. **Archiver** (`pipeline/archiver.py`) — tar.gz + SHA-256 manifest → Cloudflare R2 (`crows-nest-archive` bucket)
+4. **Archiver** (`pipeline/archiver.py`) — tar.gz + SHA-256 manifest → Cloudflare R2 (`crows-nest-media-archive` bucket)
 
 ### Key files
 

--- a/pipeline/archiver.py
+++ b/pipeline/archiver.py
@@ -2,7 +2,7 @@
 Archiver for the Crow's Nest pipeline.
 
 Stage 4: creates tar.gz archives of captured media directories, generates
-SHA-256 manifests, and uploads both to the crows-nest-archive R2 bucket via
+SHA-256 manifests, and uploads both to the crows-nest-media-archive R2 bucket via
 boto3 (S3-compatible). Runs daily; processes all links with status="summarized".
 """
 
@@ -24,7 +24,7 @@ from utils import setup_logging
 
 logger = setup_logging("crows-nest.archiver")
 
-R2_BUCKET = "crows-nest-archive"
+R2_BUCKET = "crows-nest-media-archive"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Updates `R2_BUCKET` constant from `crows-nest-archive` to `crows-nest-media-archive` to match the actual Cloudflare R2 bucket
- Updates docstring and AGENTS.md references
- R2 credentials already stored in macOS Keychain

Closes #5, closes #28, closes #20

## Test plan
- [ ] Verify `R2_BUCKET` value matches Cloudflare dashboard
- [ ] Run archiver on a test item to confirm upload succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Agent: Claude Opus 4.6