### PR TITLE
fix: remove 2000-char transcript truncation

### DIFF
--- a/pipeline/summarizer.py
+++ b/pipeline/summarizer.py
@@ -247,16 +247,11 @@ def generate_note_content(
     sections.append("---\n\n## Source Details\n\n" + "\n".join(source_lines))
 
     # Transcript (collapsed) — skipped for image content
+    # Full transcript preserved; the <details> block handles readability.
     if transcript_text and content_type != "image":
-        truncated = transcript_text[:2000]
-        truncation_notice = (
-            "\n\n*(transcript truncated at 2000 chars)*"
-            if len(transcript_text) > 2000
-            else ""
-        )
         sections.append(
             f"<details><summary>Full Transcript</summary>\n\n"
-            f"{truncated}{truncation_notice}\n\n</details>"
+            f"{transcript_text}\n\n</details>"
         )
 
     return "\n\n".join(sections)

--- a/tests/pipeline/test_summarizer.py
+++ b/tests/pipeline/test_summarizer.py
@@ -117,3 +117,20 @@ def test_generate_note_content_image_no_extracted_text():
     )
     assert "![[20260319-130000-1.jpg]]" in result
     assert "## Extracted Text" not in result  # No section when empty
+
+
+def test_generate_note_content_full_transcript_not_truncated():
+    """Transcripts longer than 2000 chars must appear in full (issue #17)."""
+    long_transcript = "word " * 5000  # ~25,000 chars
+    result = generate_note_content(
+        title="Long Podcast",
+        source_url="https://example.com/podcast",
+        content_type="podcast",
+        summary="A long podcast episode.",
+        key_points=["Point one"],
+        transcript_text=long_transcript,
+        metadata={},
+    )
+    assert long_transcript.strip() in result
+    assert "truncated" not in result
+    assert "<details>" in result


### PR DESCRIPTION
## Summary
- Removes the hard 2000-character truncation limit on transcripts in Obsidian notes
- Full transcripts now flow into the `<details><summary>` collapse block
- Adds test verifying long transcripts are preserved without truncation

Closes #17

## Test plan
- [ ] `pytest tests/pipeline/test_summarizer.py` — 7/7 passing
- [ ] Process a podcast item and verify full transcript appears in note

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Agent: Claude Opus 4.6