### PR TITLE
test: add coverage for migrate_media_paths and backfill_video

### DIFF
--- a/pipeline/migrate_media_paths.py
+++ b/pipeline/migrate_media_paths.py
@@ -56,8 +56,7 @@ def migrate(db_path: str, dry_run: bool = False) -> int:
     Returns the number of rows whose paths were updated.
     """
     if not os.path.exists(db_path):
-        print(f"Database not found: {db_path}", file=sys.stderr)
-        sys.exit(1)
+        raise FileNotFoundError(f"Database not found: {db_path}")
 
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
@@ -125,7 +124,11 @@ def main() -> None:
         print("Mode: dry-run (no changes will be written)")
     print()
 
-    count = migrate(args.db, dry_run=args.dry_run)
+    try:
+        count = migrate(args.db, dry_run=args.dry_run)
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
 
     if args.dry_run:
         print(f"\n{count} row(s) would be updated.")

--- a/tests/pipeline/test_backfill_video.py
+++ b/tests/pipeline/test_backfill_video.py
@@ -1,0 +1,143 @@
+"""Tests for pipeline/backfill_video.py (issue #25)."""
+
+import os
+import sys
+import sqlite3
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../pipeline"))
+
+from backfill_video import (
+    existing_videos,
+    find_new_video,
+    query_candidates,
+    storage_estimate,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_test_db(path):
+    """Create a links table matching the schema backfill_video expects."""
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE links (
+            id INTEGER PRIMARY KEY,
+            url TEXT,
+            content_type TEXT,
+            download_path TEXT,
+            video_path TEXT,
+            status TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+    conn.commit()
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# query_candidates
+# ---------------------------------------------------------------------------
+
+class TestQueryCandidates:
+    def test_returns_audio_only_items(self, tmp_path):
+        db = tmp_path / "test.db"
+        conn = _create_test_db(db)
+        conn.execute(
+            "INSERT INTO links (id, url, content_type, download_path, video_path, status) "
+            "VALUES (1, 'https://youtube.com/1', 'youtube', '/media/1/a.m4a', NULL, 'summarized')"
+        )
+        conn.execute(
+            "INSERT INTO links (id, url, content_type, download_path, video_path, status) "
+            "VALUES (2, 'https://youtube.com/2', 'youtube', '/media/2/a.m4a', '/media/2/v.mp4', 'summarized')"
+        )
+        conn.execute(
+            "INSERT INTO links (id, url, content_type, download_path, video_path, status) "
+            "VALUES (3, 'https://tiktok.com/3', 'social_video', '/media/3/a.m4a', '', 'archived')"
+        )
+        conn.commit()
+        conn.close()
+
+        results = query_candidates(str(db))
+        ids = {r["id"] for r in results}
+        assert ids == {1, 3}  # row 2 already has video
+
+    def test_skip_podcasts(self, tmp_path):
+        db = tmp_path / "test.db"
+        conn = _create_test_db(db)
+        conn.execute(
+            "INSERT INTO links (id, url, content_type, download_path, video_path, status) "
+            "VALUES (1, 'https://pod.co/1', 'podcast', '/media/1/a.m4a', NULL, 'transcribed')"
+        )
+        conn.execute(
+            "INSERT INTO links (id, url, content_type, download_path, video_path, status) "
+            "VALUES (2, 'https://youtube.com/2', 'youtube', '/media/2/a.m4a', NULL, 'summarized')"
+        )
+        conn.commit()
+        conn.close()
+
+        results = query_candidates(str(db), skip_podcasts=True)
+        assert len(results) == 1
+        assert results[0]["id"] == 2
+
+
+# ---------------------------------------------------------------------------
+# storage_estimate
+# ---------------------------------------------------------------------------
+
+class TestStorageEstimate:
+    def test_known_types(self):
+        candidates = [
+            {"content_type": "social_video"},
+            {"content_type": "youtube"},
+        ]
+        total_mb, cost = storage_estimate(candidates)
+        assert total_mb == 50 + 500
+        assert cost == pytest.approx((550 / 1024) * 0.015)
+
+    def test_unknown_type_defaults_to_500(self):
+        total_mb, _ = storage_estimate([{"content_type": "unknown_type"}])
+        assert total_mb == 500
+
+
+# ---------------------------------------------------------------------------
+# find_new_video / existing_videos
+# ---------------------------------------------------------------------------
+
+class TestFindNewVideo:
+    def test_finds_new_file(self, tmp_path):
+        before = set()
+        video = tmp_path / "new_video.mp4"
+        video.touch()
+        result = find_new_video(str(tmp_path), before)
+        assert result == str(video)
+
+    def test_returns_none_when_no_new(self, tmp_path):
+        video = tmp_path / "old.mp4"
+        video.touch()
+        before = {str(video)}
+        assert find_new_video(str(tmp_path), before) is None
+
+    def test_ignores_non_video_extensions(self, tmp_path):
+        (tmp_path / "file.txt").touch()
+        (tmp_path / "file.m4a").touch()
+        assert find_new_video(str(tmp_path), set()) is None
+
+
+class TestExistingVideos:
+    def test_returns_video_set(self, tmp_path):
+        (tmp_path / "a.mp4").touch()
+        (tmp_path / "b.mkv").touch()
+        (tmp_path / "c.txt").touch()
+        result = existing_videos(str(tmp_path))
+        assert result == {
+            os.path.join(str(tmp_path), "a.mp4"),
+            os.path.join(str(tmp_path), "b.mkv"),
+        }
+
+    def test_handles_nonexistent_dir(self):
+        result = existing_videos("/nonexistent/path")
+        assert result == set()

--- a/tests/pipeline/test_migrate_media_paths.py
+++ b/tests/pipeline/test_migrate_media_paths.py
@@ -1,0 +1,105 @@
+"""Tests for pipeline/migrate_media_paths.py (issue #25)."""
+
+import os
+import sys
+import sqlite3
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../pipeline"))
+
+from migrate_media_paths import _reroot, migrate
+
+
+# ---------------------------------------------------------------------------
+# _reroot
+# ---------------------------------------------------------------------------
+
+class TestReroot:
+    def test_matching_prefix(self):
+        assert _reroot("/old/root/sub/file.m4a", "/old/root", "/new/root") == "/new/root/sub/file.m4a"
+
+    def test_non_matching_prefix(self):
+        assert _reroot("/other/path/file.m4a", "/old/root", "/new/root") == "/other/path/file.m4a"
+
+    def test_none_input(self):
+        assert _reroot(None, "/old", "/new") is None
+
+    def test_empty_string(self):
+        assert _reroot("", "/old", "/new") == ""
+
+
+# ---------------------------------------------------------------------------
+# migrate
+# ---------------------------------------------------------------------------
+
+def _create_test_db(path, rows):
+    """Create a minimal links table with the given rows."""
+    conn = sqlite3.connect(str(path))
+    conn.execute("""
+        CREATE TABLE links (
+            id INTEGER PRIMARY KEY,
+            download_path TEXT,
+            transcript_path TEXT
+        )
+    """)
+    for row in rows:
+        conn.execute(
+            "INSERT INTO links (id, download_path, transcript_path) VALUES (?, ?, ?)",
+            row,
+        )
+    conn.commit()
+    conn.close()
+
+
+class TestMigrate:
+    def test_updates_matching_rows(self, tmp_path, monkeypatch):
+        db = tmp_path / "test.db"
+        _create_test_db(db, [
+            (1, "/old/root/2024-01/item/audio.m4a", "/old/root/2024-01/item/audio.txt"),
+            (2, "/other/path/audio.m4a", "/other/path/audio.txt"),
+        ])
+        monkeypatch.setattr("migrate_media_paths.OLD_ROOT", "/old/root")
+        monkeypatch.setattr("migrate_media_paths.NEW_ROOT", "/new/root")
+
+        count = migrate(str(db))
+        assert count == 1
+
+        conn = sqlite3.connect(str(db))
+        conn.row_factory = sqlite3.Row
+        rows = {r["id"]: r for r in conn.execute("SELECT * FROM links").fetchall()}
+        conn.close()
+
+        assert rows[1]["download_path"] == "/new/root/2024-01/item/audio.m4a"
+        assert rows[1]["transcript_path"] == "/new/root/2024-01/item/audio.txt"
+        assert rows[2]["download_path"] == "/other/path/audio.m4a"
+
+    def test_idempotent(self, tmp_path, monkeypatch):
+        db = tmp_path / "test.db"
+        _create_test_db(db, [
+            (1, "/old/root/audio.m4a", "/old/root/audio.txt"),
+        ])
+        monkeypatch.setattr("migrate_media_paths.OLD_ROOT", "/old/root")
+        monkeypatch.setattr("migrate_media_paths.NEW_ROOT", "/new/root")
+
+        assert migrate(str(db)) == 1
+        assert migrate(str(db)) == 0  # already migrated
+
+    def test_dry_run_no_changes(self, tmp_path, monkeypatch):
+        db = tmp_path / "test.db"
+        _create_test_db(db, [
+            (1, "/old/root/audio.m4a", "/old/root/audio.txt"),
+        ])
+        monkeypatch.setattr("migrate_media_paths.OLD_ROOT", "/old/root")
+        monkeypatch.setattr("migrate_media_paths.NEW_ROOT", "/new/root")
+
+        count = migrate(str(db), dry_run=True)
+        assert count == 1
+
+        conn = sqlite3.connect(str(db))
+        row = conn.execute("SELECT download_path FROM links WHERE id = 1").fetchone()
+        conn.close()
+        assert row[0] == "/old/root/audio.m4a"  # unchanged
+
+    def test_missing_db_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="Database not found"):
+            migrate(str(tmp_path / "nonexistent.db"))


### PR DESCRIPTION
## Summary
- 8 tests for `migrate_media_paths.py`: `_reroot` edge cases, `migrate()` on temp SQLite (update, idempotency, dry-run, missing DB error)
- 9 tests for `backfill_video.py`: `query_candidates`, `storage_estimate`, `find_new_video`, `existing_videos`
- Refactored `migrate()` to raise `FileNotFoundError` instead of `sys.exit(1)` for testability

Closes #25

## Test plan
- [ ] `pytest tests/pipeline/test_migrate_media_paths.py tests/pipeline/test_backfill_video.py` — 17/17 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Agent: Claude Opus 4.6