### PR TITLE
feat: batch Signal confirmations with content context

### DIFF
--- a/pipeline/signal_listener.py
+++ b/pipeline/signal_listener.py
@@ -278,6 +278,45 @@ def send_confirmation(recipient: str, message: str) -> None:
         logger.warning("Could not send confirmation to %s: %s", recipient, exc)
 
 
+_CONTENT_TYPE_LABELS = {
+    "youtube": "YouTube video",
+    "social_video": "video",
+    "podcast": "podcast",
+    "web_page": "article",
+    "image": "image",
+}
+
+
+def _url_label(url: str, content_type: str = "") -> str:
+    """Return a short human label like 'YouTube video — youtu.be'."""
+    label = _CONTENT_TYPE_LABELS.get(content_type, "link")
+    try:
+        from urllib.parse import urlparse
+        domain = urlparse(url).hostname or url
+        # Strip common prefixes
+        for prefix in ("www.", "m.", "mobile."):
+            if domain.startswith(prefix):
+                domain = domain[len(prefix):]
+        return f"{label} — {domain}"
+    except Exception:
+        return label
+
+
+def _build_confirmation_message(labels: list[str]) -> str:
+    """Build a confirmation message for one or more saved items.
+
+    Single item: 'Saved: YouTube video — youtu.be'
+    Multiple:    'Saved 3 items: YouTube video — youtu.be, article — nyt.com, ...'
+    """
+    if len(labels) == 1:
+        return f"Saved: {labels[0]}"
+    joined = ", ".join(labels)
+    msg = f"Saved {len(labels)} items: {joined}"
+    if len(msg) > 160:
+        msg = msg[:157] + "..."
+    return msg
+
+
 def _log_message(sender: str, body: str, group: str = "") -> None:
     """Append every incoming message to a plain text log file."""
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
@@ -335,6 +374,9 @@ def run(db_path: str) -> None:
 
     image_batches, non_image_messages = _batch_image_messages(messages)
 
+    # Accumulate confirmation labels per sender for batched messaging
+    pending_confirmations: dict[str, list[str]] = {}
+
     # Process non-image messages (existing behaviour)
     for msg in non_image_messages:
         sender_id = msg["sender_id"]
@@ -374,7 +416,9 @@ def run(db_path: str) -> None:
                     db_path=db_path,
                 )
                 logger.info("Saved %s (%s) from %s", url, content_type, sender_display)
-                send_confirmation(sender_id, f"Saved: {url}")
+                pending_confirmations.setdefault(sender_id, []).append(
+                    _url_label(url, content_type)
+                )
             except sqlite3.IntegrityError:
                 logger.info("Duplicate URL skipped: %s", url)
 
@@ -428,9 +472,15 @@ def run(db_path: str) -> None:
                 "Saved image batch (%d image(s)) from %s as %s",
                 len(attachments), sender_display, synthetic_url,
             )
-            send_confirmation(sender_id, f"Saved {len(attachments)} image(s)")
+            label = f"{len(attachments)} image(s)" if len(attachments) > 1 else "image"
+            pending_confirmations.setdefault(sender_id, []).append(label)
         except sqlite3.IntegrityError:
             logger.info("Duplicate image URL skipped: %s", synthetic_url)
+
+    # Send batched confirmations — one message per sender
+    for recipient, labels in pending_confirmations.items():
+        msg = _build_confirmation_message(labels)
+        send_confirmation(recipient, msg)
 
 
 if __name__ == "__main__":

--- a/tests/pipeline/test_signal_listener.py
+++ b/tests/pipeline/test_signal_listener.py
@@ -14,6 +14,8 @@ from signal_listener import (
     receive_messages,
     _write_health,
     resolve_sender,
+    _url_label,
+    _build_confirmation_message,
 )
 
 
@@ -335,3 +337,51 @@ def test_write_health_ok(tmp_path):
         data = json.load(f)
     assert data["status"] == "ok"
     assert "error" not in data
+
+
+# --- _url_label ---
+
+def test_url_label_youtube():
+    result = _url_label("https://www.youtube.com/watch?v=abc", "youtube")
+    assert result == "YouTube video — youtube.com"
+
+def test_url_label_web_page():
+    result = _url_label("https://nytimes.com/article", "web_page")
+    assert result == "article — nytimes.com"
+
+def test_url_label_unknown_type():
+    result = _url_label("https://example.com/page", "unknown")
+    assert result == "link — example.com"
+
+def test_url_label_strips_www():
+    result = _url_label("https://www.example.com/page", "web_page")
+    assert result == "article — example.com"
+
+def test_url_label_strips_mobile():
+    result = _url_label("https://m.tiktok.com/v/123", "social_video")
+    assert result == "video — tiktok.com"
+
+
+# --- _build_confirmation_message ---
+
+def test_build_confirmation_single():
+    msg = _build_confirmation_message(["YouTube video — youtu.be"])
+    assert msg == "Saved: YouTube video — youtu.be"
+
+def test_build_confirmation_multiple():
+    msg = _build_confirmation_message(["YouTube video — youtu.be", "article — nyt.com"])
+    assert msg.startswith("Saved 2 items:")
+    assert "YouTube video" in msg
+    assert "article" in msg
+
+def test_build_confirmation_truncation():
+    labels = [f"long label {i} with lots of text padding" for i in range(10)]
+    msg = _build_confirmation_message(labels)
+    assert len(msg) <= 160
+    assert msg.endswith("...")
+
+def test_build_confirmation_no_truncation_when_short():
+    labels = ["a", "b", "c"]
+    msg = _build_confirmation_message(labels)
+    assert "..." not in msg
+    assert msg == "Saved 3 items: a, b, c"


### PR DESCRIPTION
## Summary
- Single items include context: "Saved: YouTube video — youtu.be"
- Batch processing sends one message per sender: "Saved 3 items: ..."
- 160-char truncation for SMS-friendly messages
- Adds `_url_label()` and `_build_confirmation_message()` helpers
- 9 unit tests for label generation and message formatting

**Note:** This PR targets `feat/sender-names` (#42) since both modify `signal_listener.py`. Merge #42 first, then this one.

Closes #30

## Test plan
- [x] `pytest tests/pipeline/test_signal_listener.py` — 36/36 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)