### PR TITLE
fix: sanitize Obsidian note titles in weekly log wikilinks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Two systems in one repo: an **MCP knowledge server** and a **Signal-to-Obsidian 
 - `pipeline/status.py` — dashboard (`python status.py`) and health check (`python status.py --health`)
 - `pipeline/add_link.py` — CLI to manually queue URLs
 - `pipeline/keychain_secrets.py` — macOS Keychain with env var fallback for API keys
+- `pipeline/fix_obsidian_names.py` — fixes Obsidian filenames with banned characters and updates weekly log wikilinks to match (dry run by default, pass `--apply` to write changes)
 
 ### Running manually
 
@@ -29,6 +30,8 @@ cd ~/Developer/second-brain/crows-nest
 .venv/bin/python pipeline/add_link.py "URL"   # queue a URL
 .venv/bin/python pipeline/processor.py        # process pending
 .venv/bin/python pipeline/summarizer.py       # summarize transcribed
+.venv/bin/python pipeline/fix_obsidian_names.py          # dry run: check for bad filenames/wikilinks
+.venv/bin/python pipeline/fix_obsidian_names.py --apply  # fix bad filenames/wikilinks
 ```
 
 ### Scheduling

--- a/pipeline/fix_obsidian_names.py
+++ b/pipeline/fix_obsidian_names.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Fix Obsidian note filenames and weekly log wikilinks containing banned characters.
+
+Scans the Clippings directory for filenames with characters Obsidian prohibits,
+renames them, and updates any wikilinks in weekly log files to match.
+
+Usage:
+    python fix_obsidian_names.py          # dry run (default)
+    python fix_obsidian_names.py --apply  # apply changes
+"""
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from config import OBSIDIAN_VAULT
+
+CLIPPINGS_DIR = os.path.join(OBSIDIAN_VAULT, "2 - AREAS", "CLIPPINGS - Need Sorting")
+INBOX_DIR = os.path.join(OBSIDIAN_VAULT, "0 - INBOX")
+
+UNSAFE = re.compile(r'[<>:"/\\|?*\[\]#^]')
+
+
+def sanitize(name: str) -> str:
+    result = UNSAFE.sub("", name)
+    result = re.sub(r"\s+", " ", result)
+    return result.strip()
+
+
+def fix_filenames(apply: bool) -> dict[str, str]:
+    """Rename clipping files with banned characters. Returns {old_stem: new_stem}."""
+    renames = {}
+    if not os.path.isdir(CLIPPINGS_DIR):
+        print(f"Clippings directory not found: {CLIPPINGS_DIR}")
+        return renames
+
+    for fname in os.listdir(CLIPPINGS_DIR):
+        if not fname.endswith(".md"):
+            continue
+        stem = fname[:-3]
+        clean = sanitize(stem)
+        if clean != stem:
+            renames[stem] = clean
+            old_path = os.path.join(CLIPPINGS_DIR, fname)
+            new_path = os.path.join(CLIPPINGS_DIR, f"{clean}.md")
+
+            # Handle collision
+            counter = 1
+            while os.path.exists(new_path) and new_path != old_path:
+                new_path = os.path.join(CLIPPINGS_DIR, f"{clean} ({counter}).md")
+                counter += 1
+
+            if apply:
+                os.rename(old_path, new_path)
+                print(f"  RENAMED: {fname} -> {os.path.basename(new_path)}")
+            else:
+                print(f"  WOULD RENAME: {fname} -> {os.path.basename(new_path)}")
+
+    # Also check ROUNDUP subdirectory
+    roundup_dir = os.path.join(CLIPPINGS_DIR, "ROUNDUP")
+    if os.path.isdir(roundup_dir):
+        for fname in os.listdir(roundup_dir):
+            if not fname.endswith(".md"):
+                continue
+            stem = fname[:-3]
+            clean = sanitize(stem)
+            if clean != stem:
+                renames[stem] = clean
+                old_path = os.path.join(roundup_dir, fname)
+                new_path = os.path.join(roundup_dir, f"{clean}.md")
+
+                counter = 1
+                while os.path.exists(new_path) and new_path != old_path:
+                    new_path = os.path.join(roundup_dir, f"{clean} ({counter}).md")
+                    counter += 1
+
+                if apply:
+                    os.rename(old_path, new_path)
+                    print(f"  RENAMED: ROUNDUP/{fname} -> {os.path.basename(new_path)}")
+                else:
+                    print(f"  WOULD RENAME: ROUNDUP/{fname} -> {os.path.basename(new_path)}")
+
+    return renames
+
+
+def fix_weekly_logs(apply: bool, renames: dict[str, str]) -> None:
+    """Fix wikilinks in weekly log files."""
+    if not os.path.isdir(INBOX_DIR):
+        print(f"Inbox directory not found: {INBOX_DIR}")
+        return
+
+    for fname in os.listdir(INBOX_DIR):
+        if not fname.startswith("Weekly Links") or not fname.endswith(".md"):
+            continue
+
+        filepath = os.path.join(INBOX_DIR, fname)
+        with open(filepath, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        original = content
+
+        # Fix all wikilinks that contain banned characters
+        def fix_wikilink(m: re.Match) -> str:
+            inner = m.group(1)
+            clean = sanitize(inner)
+            # If we renamed the file, use the renamed version
+            if inner in renames:
+                clean = renames[inner]
+            return f"[[{clean}]]"
+
+        content = re.sub(r"\[\[([^\]]+)\]\]", fix_wikilink, content)
+
+        if content != original:
+            changes = []
+            for old_line, new_line in zip(original.splitlines(), content.splitlines()):
+                if old_line != new_line:
+                    changes.append(f"    - {old_line.strip()}")
+                    changes.append(f"    + {new_line.strip()}")
+
+            if apply:
+                with open(filepath, "w", encoding="utf-8") as f:
+                    f.write(content)
+                print(f"  FIXED: {fname}")
+            else:
+                print(f"  WOULD FIX: {fname}")
+
+            for line in changes:
+                print(line)
+
+
+def main():
+    apply = "--apply" in sys.argv
+
+    if not apply:
+        print("DRY RUN (pass --apply to make changes)\n")
+
+    print("=== Checking clipping filenames ===")
+    renames = fix_filenames(apply)
+    if not renames:
+        print("  All filenames OK")
+
+    print("\n=== Checking weekly log wikilinks ===")
+    fix_weekly_logs(apply, renames)
+
+    if not apply and renames:
+        print(f"\n{len(renames)} file(s) would be renamed. Run with --apply to fix.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/summarizer.py
+++ b/pipeline/summarizer.py
@@ -1050,11 +1050,12 @@ def run(db_path: str) -> None:
             )
 
             note_path = write_obsidian_note(title, frontmatter, body)
+            note_title = os.path.splitext(os.path.basename(note_path))[0]
 
             try:
                 _append_to_weekly_log(
                     inbox_dir=os.path.join(OBSIDIAN_VAULT, "0 - INBOX"),
-                    title=title,
+                    title=note_title,
                     url=link["url"],
                     content_type=link["content_type"] or "web_page",
                     source=link.get("sender") or link.get("source_type") or "unknown",

--- a/pipeline/summarizer.py
+++ b/pipeline/summarizer.py
@@ -900,7 +900,7 @@ def _append_to_weekly_log(
             f.write(content)
 
     section = CONTENT_TYPE_SECTION_MAP.get(content_type, "Other")
-    entry_line = f"- {capture_date.isoformat()} \u2014 [[{title}]] \u00b7 [{content_type}]({url}) \u00b7 via {source}\n"
+    entry_line = f"- {capture_date.isoformat()} \u2014 [[{sanitize_title(title)}]] \u00b7 [{content_type}]({url}) \u00b7 via {source}\n"
 
     with open(filepath, "r", encoding="utf-8") as f:
         lines = f.readlines()

--- a/pipeline/utils.py
+++ b/pipeline/utils.py
@@ -24,7 +24,7 @@ def _strip_trailing_punct(url: str) -> str:
 
 def sanitize_title(title: str, max_length: int = 100) -> str:
     """Remove chars unsafe for filenames, collapse whitespace, truncate."""
-    unsafe = r'[<>:"/\\|?*]'
+    unsafe = r'[<>:"/\\|?*\[\]#]'
     result = re.sub(unsafe, "", title)
     result = re.sub(r"\s+", " ", result)
     result = result[:max_length]

--- a/pipeline/utils.py
+++ b/pipeline/utils.py
@@ -24,7 +24,7 @@ def _strip_trailing_punct(url: str) -> str:
 
 def sanitize_title(title: str, max_length: int = 100) -> str:
     """Remove chars unsafe for filenames, collapse whitespace, truncate."""
-    unsafe = r'[<>:"/\\|?*\[\]#]'
+    unsafe = r'[<>:"/\\|?*\[\]#^]'
     result = re.sub(unsafe, "", title)
     result = re.sub(r"\s+", " ", result)
     result = result[:max_length]

--- a/tests/pipeline/test_utils.py
+++ b/tests/pipeline/test_utils.py
@@ -28,6 +28,14 @@ def test_sanitize_title_strips_whitespace():
     assert utils.sanitize_title("  hello  ") == "hello"
 
 
+def test_sanitize_title_strips_brackets_and_hash():
+    result = utils.sanitize_title("Title [with] #brackets")
+    assert "[" not in result
+    assert "]" not in result
+    assert "#" not in result
+    assert result == "Title with brackets"
+
+
 def test_extract_urls_single():
     text = "Check out https://example.com for more info."
     urls = utils.extract_urls(text)

--- a/tests/pipeline/test_utils.py
+++ b/tests/pipeline/test_utils.py
@@ -28,12 +28,13 @@ def test_sanitize_title_strips_whitespace():
     assert utils.sanitize_title("  hello  ") == "hello"
 
 
-def test_sanitize_title_strips_brackets_and_hash():
-    result = utils.sanitize_title("Title [with] #brackets")
+def test_sanitize_title_strips_brackets_hash_and_caret():
+    result = utils.sanitize_title("Title [with] #brackets ^block")
     assert "[" not in result
     assert "]" not in result
     assert "#" not in result
-    assert result == "Title with brackets"
+    assert "^" not in result
+    assert result == "Title with brackets block"
 
 
 def test_extract_urls_single():

--- a/tests/test_weekly_log.py
+++ b/tests/test_weekly_log.py
@@ -66,6 +66,22 @@ def test_appends_to_existing_weekly_log(tmp_path):
     assert "[[Second Article]]" in content
 
 
+def test_wikilink_uses_sanitized_title(tmp_path):
+    """Wikilinks should use the sanitized title to match the actual filename."""
+    _append_to_weekly_log(
+        inbox_dir=str(tmp_path),
+        title="Claude How-To: From Basics to Advanced",
+        url="https://example.com/video",
+        content_type="social_video",
+        source="cli",
+        capture_date=date(2026, 3, 30),
+    )
+
+    content = (tmp_path / "Weekly Links — 2026-W14.md").read_text()
+    assert "[[Claude How-To From Basics to Advanced]]" in content
+    assert "[[Claude How-To:" not in content
+
+
 def test_maps_content_types_to_sections(tmp_path):
     """Each content type maps to the correct section header."""
     for ctype, section in CONTENT_TYPE_SECTION_MAP.items():

--- a/tests/test_weekly_log.py
+++ b/tests/test_weekly_log.py
@@ -82,6 +82,21 @@ def test_wikilink_uses_sanitized_title(tmp_path):
     assert "[[Claude How-To:" not in content
 
 
+def test_wikilink_preserves_collision_suffix(tmp_path):
+    """When caller passes a filename stem with collision suffix, wikilink uses it as-is."""
+    _append_to_weekly_log(
+        inbox_dir=str(tmp_path),
+        title="Duplicate Title (1)",
+        url="https://example.com/dup",
+        content_type="web_page",
+        source="Signal",
+        capture_date=date(2026, 3, 30),
+    )
+
+    content = (tmp_path / "Weekly Links — 2026-W14.md").read_text()
+    assert "[[Duplicate Title (1)]]" in content
+
+
 def test_maps_content_types_to_sections(tmp_path):
     """Each content type maps to the correct section header."""
     for ctype, section in CONTENT_TYPE_SECTION_MAP.items():


### PR DESCRIPTION
## Summary
- Expanded `sanitize_title()` to also strip `[]#` (Obsidian-banned filename characters)
- Fixed weekly log wikilinks to use sanitized titles, matching the actual note filenames
- Added tests for bracket/hash stripping and wikilink-to-filename consistency

## Test plan
- [x] `pytest tests/pipeline/test_utils.py tests/test_weekly_log.py -v` — 17 passed
- [ ] Verify fixed wikilinks resolve in Obsidian (`Weekly Links — 2026-W14.md`)
- [ ] Process a new link with a colon in the title and confirm the wikilink matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)