### PR TITLE
fix: resolve RSS pipeline import failure outside project root

### DIFF
--- a/pipeline/archiver.py
+++ b/pipeline/archiver.py
@@ -14,8 +14,8 @@ import shutil
 import tarfile
 import tempfile
 from datetime import datetime, timezone
-
 import boto3
+import requests
 from botocore.config import Config as BotoConfig
 
 from db import DB_PATH, claim_link, get_pending, log_processing, update_status
@@ -95,6 +95,32 @@ def upload_to_r2(local_path: str, r2_key: str) -> bool:
         return False
 
 
+def save_to_readwise(url: str) -> bool:
+    """Save a web page URL to Readwise Reader's archive. Returns True on success."""
+    token = get_secret("READWISE_TOKEN")
+    if not token:
+        logger.warning("READWISE_TOKEN not found, skipping Readwise save")
+        return False
+
+    try:
+        resp = requests.post(
+            "https://readwise.io/api/v3/save/",
+            headers={"Authorization": f"Token {token}"},
+            json={
+                "url": url,
+                "location": "archive",
+                "tags": ["crows-nest"],
+            },
+            timeout=15,
+        )
+        resp.raise_for_status()
+        logger.info("Saved to Readwise archive: %s", url)
+        return True
+    except Exception as e:
+        logger.error("Readwise save failed for %s: %s", url, e)
+        return False
+
+
 # ---------------------------------------------------------------------------
 # R2 key derivation
 # ---------------------------------------------------------------------------
@@ -151,13 +177,18 @@ def run(db_path: str) -> None:
 
         logger.info("link %d: archiving %s", link_id, url)
 
-        # No media directory — mark archived and skip upload
+        # No media directory — save articles to Readwise, then mark archived
         if not media_dir or not os.path.isdir(media_dir):
             logger.info(
                 "link %d: no media dir (%r), marking archived with path=none",
                 link_id,
                 media_dir,
             )
+
+            # Save web pages to Readwise Reader archive
+            if content_type == "web_page":
+                save_to_readwise(url)
+
             update_status(
                 link_id=link_id,
                 status="archived",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ mcp-knowledge-server = "mcp_knowledge.server:main"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "httpx>=0.24"]
-archive = ["boto3>=1.28"]
+archive = ["boto3>=1.28", "requests>=2.31"]
 semantic = ["chromadb>=0.5", "fastembed>=0.3"]
 rss = ["feedparser>=6.0", "requests>=2.31"]
 all = ["crows-nest[archive,semantic,rss]"]

--- a/src/mcp_knowledge/server.py
+++ b/src/mcp_knowledge/server.py
@@ -21,12 +21,13 @@ logger = logging.getLogger("mcp_knowledge.server")
 from . import config, knowledge
 
 # ---------------------------------------------------------------------------
-# Pipeline db import — pipeline/ lives at the project root, one level above src/
+# Pipeline db import — pipeline/ is a package at the project root, above src/
+# Add the project root to sys.path so `from pipeline.db import ...` resolves.
 # ---------------------------------------------------------------------------
 
-_PIPELINE_DIR = str(Path(__file__).resolve().parent.parent.parent / "pipeline")
-if _PIPELINE_DIR not in sys.path:
-    sys.path.insert(0, _PIPELINE_DIR)
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
 
 try:
     from pipeline.db import (
@@ -39,7 +40,7 @@ try:
     from pipeline.config import DB_PATH as _DB_PATH
     _RSS_AVAILABLE = True
 except ImportError as _rss_exc:
-    logger.warning("RSS db unavailable: %s", _rss_exc)
+    logger.warning("RSS db unavailable — pipeline import failed: %s", _rss_exc)
     _RSS_AVAILABLE = False
 
 mcp = FastMCP(config.SERVER_NAME)

--- a/tests/test_rss_mcp_tools.py
+++ b/tests/test_rss_mcp_tools.py
@@ -2,7 +2,7 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "pipeline"))
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from pipeline.db import (
     init_db,


### PR DESCRIPTION
## Summary
- Fix `sys.path` resolution bug that caused RSS tools to report "pipeline deps not installed" when the MCP server was launched from any CWD other than the project root. The code was adding `pipeline/` to `sys.path` instead of the project root — since `pipeline/` is a package, Python needs its parent on the path.
- Add Readwise Reader archival for `web_page` content types in the archiver pipeline
- Improve import error message for easier debugging
- Fix same `sys.path` pattern in test file for consistency

Fixes #36

## Test plan
- [x] `pytest tests/test_rss_mcp_tools.py` passes
- [ ] Restart crows-nest MCP server and verify `list_recent_articles` returns data instead of the error
- [ ] Verify Readwise save works for web_page items (requires `READWISE_TOKEN` in keychain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)