### PR TITLE
feat: shareable media archives via R2 custom domain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,8 @@ Two systems in one repo: an **MCP knowledge server** and a **Signal-to-Obsidian 
 
 1. **Listener** (`pipeline/signal_listener.py`) — polls signal-cli every 5 min, extracts URLs and image batches, saves to SQLite
 2. **Processor** (`pipeline/processor.py`) — downloads media, transcribes audio/video with Whisper, scrapes web pages
-3. **Summarizer** (`pipeline/summarizer.py`) — calls Claude Haiku via OpenRouter for structured analysis, writes Obsidian notes to `0 - INBOX/Clippings/`
-4. **Archiver** (`pipeline/archiver.py`) — tar.gz + SHA-256 manifest → Cloudflare R2 (`crows-nest-media-archive` bucket)
+3. **Summarizer** (`pipeline/summarizer.py`) — calls Claude Haiku via OpenRouter for structured analysis, writes Obsidian notes to `2 - AREAS/INTERNET CLIPPINGS/`
+4. **Archiver** (`pipeline/archiver.py`) — uploads individual media files to R2 with Content-Type headers for inline playback, generates share URLs via `share.bymarkriechers.com`, writes them to DB and Obsidian note. Web pages are saved to Readwise Reader instead.
 
 ### Key files
 
@@ -20,6 +20,8 @@ Two systems in one repo: an **MCP knowledge server** and a **Signal-to-Obsidian 
 - `pipeline/status.py` — dashboard (`python status.py`) and health check (`python status.py --health`)
 - `pipeline/add_link.py` — CLI to manually queue URLs
 - `pipeline/keychain_secrets.py` — macOS Keychain with env var fallback for API keys
+- `pipeline/sync_clippings.py` — reusable tool to sync Obsidian clippings with DB and current spec (idempotent, rule-based normalization)
+- `pipeline/backfill_video.py` — download video for items that only have audio
 
 ### Running manually
 

--- a/pipeline/archiver.py
+++ b/pipeline/archiver.py
@@ -1,21 +1,22 @@
 """
 Archiver for the Crow's Nest pipeline.
 
-Stage 4: creates tar.gz archives of captured media directories, generates
-SHA-256 manifests, and uploads both to the crows-nest-media-archive R2 bucket via
-boto3 (S3-compatible). Runs daily; processes all links with status="summarized".
+Stage 4: uploads individual media files to the crows-nest-media-archive R2 bucket
+with proper Content-Type headers for inline browser playback, generates share URLs
+via the share.bymarkriechers.com custom domain, and writes them back to the database
+and Obsidian note. Web pages are saved to Readwise Reader instead.
 """
 
 import argparse
 import hashlib
 import json
 import os
-import shutil
-import tarfile
+import re
 import tempfile
 from datetime import datetime, timezone
 
 import boto3
+import requests
 from botocore.config import Config as BotoConfig
 
 from db import DB_PATH, claim_link, get_pending, log_processing, update_status
@@ -25,6 +26,25 @@ from utils import setup_logging
 logger = setup_logging("crows-nest.archiver")
 
 R2_BUCKET = "crows-nest-media-archive"
+SHARE_DOMAIN = "https://share.bymarkriechers.com"
+
+MIME_TYPES = {
+    ".mp4": "video/mp4",
+    ".m4a": "audio/mp4",
+    ".mp3": "audio/mpeg",
+    ".webm": "video/webm",
+    ".mkv": "video/x-matroska",
+    ".json": "application/json",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
+
+# Extension priority for finding the primary shareable media file
+_SHAREABLE_EXTENSIONS = (".mp4", ".webm", ".mkv", ".m4a", ".mp3",
+                         ".jpg", ".jpeg", ".png", ".gif", ".webp")
 
 
 # ---------------------------------------------------------------------------
@@ -39,33 +59,6 @@ def compute_sha256(filepath: str) -> str:
         for chunk in iter(lambda: f.read(65536), b""):
             h.update(chunk)
     return h.hexdigest()
-
-
-def create_archive(media_dir: str, output_path: str) -> list[dict]:
-    """Create a tar.gz archive of media_dir at output_path.
-
-    Returns an inventory list of dicts with keys: name, size, sha256.
-    """
-    inventory = []
-
-    with tarfile.open(output_path, "w:gz") as tar:
-        for dirpath, _dirnames, filenames in os.walk(media_dir):
-            for filename in sorted(filenames):
-                full_path = os.path.join(dirpath, filename)
-                arcname = os.path.relpath(full_path, start=os.path.dirname(media_dir))
-                tar.add(full_path, arcname=arcname)
-                inventory.append(
-                    {
-                        "name": arcname,
-                        "size": os.path.getsize(full_path),
-                        "sha256": compute_sha256(full_path),
-                    }
-                )
-
-    logger.info(
-        "created archive %s (%d files)", output_path, len(inventory)
-    )
-    return inventory
 
 
 def get_r2_client():
@@ -84,10 +77,14 @@ def get_r2_client():
 
 
 def upload_to_r2(local_path: str, r2_key: str) -> bool:
-    """Upload a file to R2. Returns True on success."""
+    """Upload a file to R2 with auto-detected Content-Type. Returns True on success."""
     try:
         client = get_r2_client()
-        client.upload_file(local_path, R2_BUCKET, r2_key)
+        ext = os.path.splitext(local_path)[1].lower()
+        extra_args = {}
+        if ext in MIME_TYPES:
+            extra_args["ContentType"] = MIME_TYPES[ext]
+        client.upload_file(local_path, R2_BUCKET, r2_key, ExtraArgs=extra_args)
         logger.info("Uploaded %s -> r2://%s/%s", local_path, R2_BUCKET, r2_key)
         return True
     except Exception as e:
@@ -95,22 +92,88 @@ def upload_to_r2(local_path: str, r2_key: str) -> bool:
         return False
 
 
+def save_to_readwise(url: str) -> str | None:
+    """Save a web page URL to Readwise Reader's archive.
+
+    Returns the Readwise Reader URL on success, None on failure.
+    """
+    token = get_secret("READWISE_TOKEN")
+    if not token:
+        logger.warning("READWISE_TOKEN not found, skipping Readwise save")
+        return None
+
+    try:
+        resp = requests.post(
+            "https://readwise.io/api/v3/save/",
+            headers={"Authorization": f"Token {token}"},
+            json={
+                "url": url,
+                "location": "archive",
+                "tags": ["crows-nest"],
+            },
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        reader_url = data.get("url", "")
+        logger.info("Saved to Readwise archive: %s -> %s", url, reader_url)
+        return reader_url or None
+    except Exception as e:
+        logger.error("Readwise save failed for %s: %s", url, e)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Media file discovery
+# ---------------------------------------------------------------------------
+
+
+def find_shareable_media(media_dir: str, video_path: str | None = None) -> str | None:
+    """Find the primary shareable media file in a directory.
+
+    Prefers video_path if provided and valid, then scans by extension priority:
+    .mp4 > .webm > .mkv > .m4a > .mp3
+    """
+    if video_path and os.path.isfile(video_path):
+        return video_path
+
+    if not os.path.isdir(media_dir):
+        return None
+
+    files_by_ext: dict[str, list[str]] = {}
+    for name in os.listdir(media_dir):
+        ext = os.path.splitext(name)[1].lower()
+        if ext in _SHAREABLE_EXTENSIONS:
+            files_by_ext.setdefault(ext, []).append(os.path.join(media_dir, name))
+
+    for ext in _SHAREABLE_EXTENSIONS:
+        if ext in files_by_ext:
+            # Pick the largest file of this type (handles multiple downloads)
+            return max(files_by_ext[ext], key=os.path.getsize)
+
+    return None
+
+
 # ---------------------------------------------------------------------------
 # R2 key derivation
 # ---------------------------------------------------------------------------
 
 
-def _r2_key_from_media_path(media_path: str, title: str) -> str:
-    """Derive an R2 key from the media directory path.
+def slugify(text: str, max_length: int = 80) -> str:
+    """Convert text to a URL-friendly slug."""
+    text = text.lower()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_]+", "-", text)
+    text = re.sub(r"-+", "-", text).strip("-")
+    return text[:max_length].rstrip("-")
 
-    Pattern: {YYYY}/{MM}/{title}.tar.gz
-    Falls back to today's date if the path doesn't contain a YYYY-MM segment.
+
+def make_r2_key(media_dir: str, media_file: str) -> str:
+    """Generate a clean R2 key from the media directory and file.
+
+    Pattern: {YYYY}/{MM}/{slug}.{ext}
     """
-    # media_path is typically {CROWS_NEST_HOME}/media/YYYY-MM/sanitized-title
-    basename = os.path.basename(media_path.rstrip("/"))
-    parent = os.path.basename(os.path.dirname(media_path.rstrip("/")))
-
-    # parent should look like "2025-06"
+    parent = os.path.basename(os.path.dirname(media_dir.rstrip("/")))
     try:
         year, month = parent.split("-")
         int(year)
@@ -120,8 +183,59 @@ def _r2_key_from_media_path(media_path: str, title: str) -> str:
         year = now.strftime("%Y")
         month = now.strftime("%m")
 
-    safe_title = basename or title
-    return f"{year}/{month}/{safe_title}.tar.gz"
+    basename = os.path.splitext(os.path.basename(media_file))[0]
+    ext = os.path.splitext(media_file)[1].lower()
+    slug = slugify(basename)
+
+    return f"{year}/{month}/{slug}{ext}"
+
+
+# ---------------------------------------------------------------------------
+# Obsidian note patching
+# ---------------------------------------------------------------------------
+
+
+def update_obsidian_note(note_path: str, share_url: str) -> bool:
+    """Add share-url to an Obsidian note's frontmatter. Idempotent."""
+    if not note_path or not os.path.isfile(note_path):
+        return False
+
+    with open(note_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    if "share-url:" in content:
+        return False  # Already has it
+
+    # Insert share-url before the closing --- of frontmatter
+    # Find the second --- (closing frontmatter delimiter)
+    if content.startswith("---"):
+        close_idx = content.index("---", 3)
+        # Ensure we're on a new line before inserting
+        prefix = "" if content[close_idx - 1] == "\n" else "\n"
+        content = (
+            content[:close_idx]
+            + f"{prefix}share-url: {share_url}\n"
+            + content[close_idx:]
+        )
+
+    # Add to Source Details section if present
+    source_marker = "- **Original URL**:"
+    if source_marker in content:
+        if "readwise.io" in share_url or "read.readwise.io" in share_url:
+            insert_line = f"- **Readwise**: [Read in Reader]({share_url})\n"
+        else:
+            filename = os.path.basename(share_url)
+            insert_line = f"- **Archived Media**: [{filename}]({share_url})\n"
+        idx = content.index(source_marker)
+        # Find end of that line
+        eol = content.index("\n", idx)
+        content = content[: eol + 1] + insert_line + content[eol + 1 :]
+
+    with open(note_path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+    logger.info("Updated Obsidian note with share URL: %s", note_path)
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +255,7 @@ def run(db_path: str) -> None:
         obsidian_note = link.get("obsidian_note_path") or ""
         content_type = link.get("content_type") or "unknown"
         captured_at = link.get("created_at") or ""
+        video_path = link.get("video_path")
 
         claimed = claim_link(
             link_id, from_status="summarized", to_status="archiving", db_path=db_path
@@ -151,17 +266,31 @@ def run(db_path: str) -> None:
 
         logger.info("link %d: archiving %s", link_id, url)
 
-        # No media directory — mark archived and skip upload
+        # If download_path is a file, use its parent directory
+        if media_dir and os.path.isfile(media_dir):
+            media_dir = os.path.dirname(media_dir)
+
+        # No media directory — save articles to Readwise, then mark archived
         if not media_dir or not os.path.isdir(media_dir):
             logger.info(
                 "link %d: no media dir (%r), marking archived with path=none",
                 link_id,
                 media_dir,
             )
+
+            # Save web pages to Readwise Reader archive
+            share_url = None
+            if content_type == "web_page":
+                reader_url = save_to_readwise(url)
+                if reader_url:
+                    share_url = reader_url
+                    update_obsidian_note(obsidian_note, reader_url)
+
             update_status(
                 link_id=link_id,
                 status="archived",
                 archive_path="none",
+                share_url=share_url,
                 db_path=db_path,
             )
             log_processing(
@@ -170,59 +299,65 @@ def run(db_path: str) -> None:
             continue
 
         try:
-            title = os.path.basename(media_dir.rstrip("/"))
-            r2_key = _r2_key_from_media_path(media_dir, title)
-            manifest_key = r2_key.replace(".tar.gz", ".manifest.json")
+            # Find the primary shareable media file
+            media_file = find_shareable_media(media_dir, video_path)
+            if not media_file:
+                logger.warning("link %d: no shareable media found in %s", link_id, media_dir)
+                update_status(
+                    link_id=link_id,
+                    status="archived",
+                    archive_path="none",
+                    db_path=db_path,
+                )
+                log_processing(link_id, "archiver", "skipped", "no shareable media", db_path)
+                continue
 
-            with tempfile.TemporaryDirectory() as tmpdir:
-                archive_path = os.path.join(tmpdir, f"{title}.tar.gz")
-                manifest_path = os.path.join(tmpdir, f"{title}.manifest.json")
+            # Generate R2 key and upload
+            r2_key = make_r2_key(media_dir, media_file)
+            media_ok = upload_to_r2(media_file, r2_key)
+            if not media_ok:
+                raise RuntimeError(f"media upload failed for key: {r2_key}")
 
-                # Copy Obsidian note into media dir so it's included in the archive
-                if obsidian_note and os.path.isfile(obsidian_note):
-                    note_dest = os.path.join(media_dir, "obsidian-note.md")
-                    shutil.copy2(obsidian_note, note_dest)
-                    logger.info("link %d: included obsidian note in archive", link_id)
-
-                # Build archive and inventory
-                inventory = create_archive(media_dir, archive_path)
-
-                # Build manifest
+            # Upload manifest
+            manifest_key = re.sub(r"\.[^.]+$", ".manifest.json", r2_key)
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False, encoding="utf-8"
+            ) as f:
                 manifest = {
                     "url": url,
                     "content_type": content_type,
                     "captured_at": captured_at,
-                    "obsidian_note": obsidian_note,
+                    "media_file": os.path.basename(media_file),
+                    "media_size": os.path.getsize(media_file),
+                    "media_sha256": compute_sha256(media_file),
                     "r2_key": r2_key,
-                    "files": inventory,
+                    "obsidian_note": obsidian_note,
                 }
-                with open(manifest_path, "w", encoding="utf-8") as f:
-                    json.dump(manifest, f, indent=2)
+                json.dump(manifest, f, indent=2)
+                manifest_path = f.name
 
-                # Upload archive
-                archive_ok = upload_to_r2(archive_path, r2_key)
-                if not archive_ok:
-                    raise RuntimeError(f"archive upload failed for key: {r2_key}")
+            try:
+                upload_to_r2(manifest_path, manifest_key)
+            finally:
+                os.unlink(manifest_path)
 
-                # Upload manifest
-                manifest_ok = upload_to_r2(manifest_path, manifest_key)
-                if not manifest_ok:
-                    raise RuntimeError(
-                        f"manifest upload failed for key: {manifest_key}"
-                    )
+            # Generate share URL and update Obsidian note
+            share_url = f"{SHARE_DOMAIN}/{r2_key}"
+            update_obsidian_note(obsidian_note, share_url)
 
-            # Mark archived
+            # Mark archived with share URL
             r2_uri = f"r2://{R2_BUCKET}/{r2_key}"
             update_status(
                 link_id=link_id,
                 status="archived",
                 archive_path=r2_uri,
+                share_url=share_url,
                 db_path=db_path,
             )
             log_processing(
-                link_id, "archiver", "success", f"r2_key: {r2_key}", db_path
+                link_id, "archiver", "success", f"share_url: {share_url}", db_path
             )
-            logger.info("link %d: archived -> %s", link_id, r2_uri)
+            logger.info("link %d: archived -> %s", link_id, share_url)
 
         except Exception as exc:
             error_msg = str(exc)

--- a/pipeline/archiver.py
+++ b/pipeline/archiver.py
@@ -165,7 +165,7 @@ def slugify(text: str, max_length: int = 80) -> str:
     text = re.sub(r"[^\w\s-]", "", text)
     text = re.sub(r"[\s_]+", "-", text)
     text = re.sub(r"-+", "-", text).strip("-")
-    return text[:max_length].rstrip("-")
+    return text[:max_length].rstrip("-") or "untitled"
 
 
 def make_r2_key(media_dir: str, media_file: str) -> str:
@@ -207,9 +207,11 @@ def update_obsidian_note(note_path: str, share_url: str) -> bool:
         return False  # Already has it
 
     # Insert share-url before the closing --- of frontmatter
-    # Find the second --- (closing frontmatter delimiter)
     if content.startswith("---"):
-        close_idx = content.index("---", 3)
+        close_idx = content.find("---", 3)
+        if close_idx == -1:
+            logger.warning("Malformed frontmatter in %s, skipping", note_path)
+            return False
         # Ensure we're on a new line before inserting
         prefix = "" if content[close_idx - 1] == "\n" else "\n"
         content = (

--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -52,7 +52,7 @@ MESSAGE_LOG = os.path.join(LOG_DIR, "signal-messages.log")
 SIGNAL_HEALTH_FILE = os.path.join(LOG_DIR, "signal-health.json")
 WHISPER_SCRIPT = os.path.join(SCRIPTS_DIR, "whisper-transcribe.sh")
 
-OBSIDIAN_CLIPPINGS = os.path.join(OBSIDIAN_VAULT, "2 - AREAS", "CLIPPINGS - Need Sorting")
+OBSIDIAN_CLIPPINGS = os.path.join(OBSIDIAN_VAULT, "2 - AREAS", "INTERNET CLIPPINGS")
 OBSIDIAN_ARCHIVE = os.path.join(OBSIDIAN_VAULT, "4 - ARCHIVE")
 
 

--- a/pipeline/db.py
+++ b/pipeline/db.py
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS links (
     obsidian_note_path TEXT,
     archive_path     TEXT,
     video_path       TEXT,
+    share_url        TEXT,
     error            TEXT,
     retry_count      INTEGER NOT NULL DEFAULT 0,
     metadata         TEXT
@@ -114,12 +115,13 @@ def init_db(db_path: str = DB_PATH) -> None:
         conn.executescript(SCHEMA)
         conn.executescript(RSS_SCHEMA)
         conn.commit()
-        # Migrate existing databases: add video_path if missing
-        try:
-            conn.execute("ALTER TABLE links ADD COLUMN video_path TEXT")
-            conn.commit()
-        except sqlite3.OperationalError:
-            pass  # Column already exists
+        # Migrate existing databases: add columns if missing
+        for col in ("video_path TEXT", "share_url TEXT"):
+            try:
+                conn.execute(f"ALTER TABLE links ADD COLUMN {col}")
+                conn.commit()
+            except sqlite3.OperationalError:
+                pass  # Column already exists
     finally:
         conn.close()
 

--- a/pipeline/sync_clippings.py
+++ b/pipeline/sync_clippings.py
@@ -56,7 +56,9 @@ def parse_frontmatter(content: str) -> tuple[dict, str]:
     if not content.startswith("---"):
         return {}, content
 
-    close = content.index("---", 3)
+    close = content.find("---", 3)
+    if close == -1:
+        return {}, content
     fm_text = content[3:close].strip()
     body = content[close + 3:].lstrip("\n")
 
@@ -106,7 +108,8 @@ def serialize_frontmatter(fm: dict) -> str:
             for item in value:
                 lines.append(f"  - {item}")
         elif isinstance(value, str) and (":" in value or '"' in value or value != value.strip()):
-            lines.append(f'{key}: "{value}"')
+            escaped = value.replace('"', '\\"')
+            lines.append(f'{key}: "{escaped}"')
         else:
             lines.append(f"{key}: {value}")
     lines.append("---")

--- a/pipeline/sync_clippings.py
+++ b/pipeline/sync_clippings.py
@@ -1,0 +1,440 @@
+"""
+Sync Obsidian clippings with the Crow's Nest database and current pipeline spec.
+
+Scans vault directories for notes with the 'clippings' tag, normalizes their
+metadata to match the current spec, registers orphaned notes in the database,
+and moves notes to the canonical output directory.
+
+Designed to be re-run whenever the pipeline spec changes — add new normalization
+rules and re-run. Already-compliant notes are skipped.
+
+Usage:
+    python sync_clippings.py                    # dry-run (default)
+    python sync_clippings.py --apply            # apply fixes
+    python sync_clippings.py --scan-dir PATH    # scan a specific directory
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sqlite3
+import sys
+
+from config import OBSIDIAN_CLIPPINGS, OBSIDIAN_VAULT
+from content_types import classify_url
+from db import DB_PATH, add_link, get_connection, init_db, update_status
+from utils import setup_logging
+
+logger = setup_logging("crows-nest.sync-clippings")
+
+# The old output directory before the rename
+LEGACY_CLIPPINGS_DIR = os.path.join(OBSIDIAN_VAULT, "2 - AREAS", "CLIPPINGS - Need Sorting")
+
+# Content type to tag mapping (mirrors summarizer.py)
+CONTENT_TYPE_TAG_MAP = {
+    "youtube": "video-clip",
+    "podcast": "audio-clip",
+    "social_video": "video-clip",
+    "audio": "audio-clip",
+    "web_page": "web-clip",
+    "image": "image-clip",
+}
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_frontmatter(content: str) -> tuple[dict, str]:
+    """Parse YAML frontmatter from a markdown file.
+
+    Returns (frontmatter_dict, body) where body starts after the closing ---.
+    """
+    if not content.startswith("---"):
+        return {}, content
+
+    close = content.index("---", 3)
+    fm_text = content[3:close].strip()
+    body = content[close + 3:].lstrip("\n")
+
+    fm = {}
+    current_key = None
+    list_values = []
+
+    for line in fm_text.split("\n"):
+        # List item
+        if line.strip().startswith("- ") and current_key:
+            list_values.append(line.strip()[2:])
+            continue
+
+        # If we were collecting a list, save it
+        if list_values and current_key:
+            fm[current_key] = list_values
+            list_values = []
+
+        # Key-value pair
+        match = re.match(r"^(\S[\w-]*)\s*:\s*(.*)", line)
+        if match:
+            current_key = match.group(1)
+            value = match.group(2).strip()
+            if value:
+                # Remove surrounding quotes
+                if (value.startswith('"') and value.endswith('"')) or \
+                   (value.startswith("'") and value.endswith("'")):
+                    value = value[1:-1]
+                fm[current_key] = value
+            else:
+                # Could be start of a list
+                fm[current_key] = value
+
+    # Final list
+    if list_values and current_key:
+        fm[current_key] = list_values
+
+    return fm, body
+
+
+def serialize_frontmatter(fm: dict) -> str:
+    """Serialize a frontmatter dict back to YAML string."""
+    lines = ["---"]
+    for key, value in fm.items():
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        elif isinstance(value, str) and (":" in value or '"' in value or value != value.strip()):
+            lines.append(f'{key}: "{value}"')
+        else:
+            lines.append(f"{key}: {value}")
+    lines.append("---")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Normalization rules
+# ---------------------------------------------------------------------------
+# Each rule returns True if it made a change, False if the note was already OK.
+
+
+def rule_remove_legacy_tag(fm: dict, body: str) -> bool:
+    """Remove the 'clippings---need-sorting' tag."""
+    tags = fm.get("tags", [])
+    if not isinstance(tags, list):
+        return False
+    legacy = "clippings---need-sorting"
+    if legacy in tags:
+        tags.remove(legacy)
+        fm["tags"] = tags
+        return True
+    return False
+
+
+def rule_ensure_para(fm: dict, body: str) -> bool:
+    """Set para to 'areas'."""
+    if fm.get("para") != "areas":
+        fm["para"] = "areas"
+        return True
+    return False
+
+
+def rule_ensure_base_tags(fm: dict, body: str) -> bool:
+    """Ensure required base tags are present."""
+    tags = fm.get("tags", [])
+    if not isinstance(tags, list):
+        tags = []
+        fm["tags"] = tags
+
+    content_type = fm.get("content-type", "web_page")
+    type_tag = CONTENT_TYPE_TAG_MAP.get(content_type, "web-clip")
+    required = ["all", "clippings", type_tag, "inbox-capture"]
+
+    changed = False
+    for tag in required:
+        if tag not in tags:
+            # Insert base tags at the front, before topic tags
+            insert_idx = min(len(tags), len(required))
+            tags.insert(insert_idx, tag)
+            changed = True
+
+    return changed
+
+
+def rule_add_share_url(fm: dict, body: str, db_share_url: str | None = None) -> bool:
+    """Add share-url from DB if note doesn't have it."""
+    if "share-url" in fm:
+        return False
+    if db_share_url:
+        fm["share-url"] = db_share_url
+        return True
+    return False
+
+
+# All rules in execution order
+NORMALIZATION_RULES = [
+    ("remove_legacy_tag", rule_remove_legacy_tag),
+    ("ensure_para", rule_ensure_para),
+    ("ensure_base_tags", rule_ensure_base_tags),
+]
+
+
+# ---------------------------------------------------------------------------
+# Core sync logic
+# ---------------------------------------------------------------------------
+
+
+def find_clipping_notes(scan_dirs: list[str]) -> list[str]:
+    """Find all .md files with the 'clippings' tag in the given directories."""
+    notes = []
+    for scan_dir in scan_dirs:
+        if not os.path.isdir(scan_dir):
+            continue
+        for name in os.listdir(scan_dir):
+            if not name.endswith(".md"):
+                continue
+            path = os.path.join(scan_dir, name)
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    head = f.read(2000)
+                fm, _ = parse_frontmatter(head)
+                tags = fm.get("tags", [])
+                if isinstance(tags, list) and "clippings" in tags:
+                    notes.append(path)
+            except (OSError, ValueError):
+                continue
+    return sorted(notes)
+
+
+def get_db_urls(db_path: str) -> dict[str, dict]:
+    """Return a map of url -> row dict for all links in the DB."""
+    conn = get_connection(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT id, url, status, obsidian_note_path, share_url, download_path "
+            "FROM links"
+        ).fetchall()
+        return {row["url"]: dict(row) for row in rows}
+    finally:
+        conn.close()
+
+
+def sync_note(
+    note_path: str,
+    db_urls: dict[str, dict],
+    db_path: str,
+    apply: bool = False,
+) -> dict:
+    """Process a single note. Returns a report dict."""
+    report = {
+        "path": note_path,
+        "filename": os.path.basename(note_path),
+        "fixes": [],
+        "registered": False,
+        "moved": False,
+        "error": None,
+    }
+
+    try:
+        with open(note_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        fm, body = parse_frontmatter(content)
+        source_url = fm.get("source", "")
+
+        if not source_url:
+            report["error"] = "no source URL in frontmatter"
+            return report
+
+        # Look up in DB
+        db_row = db_urls.get(source_url)
+        db_share_url = db_row["share_url"] if db_row else None
+
+        # Run normalization rules
+        for rule_name, rule_fn in NORMALIZATION_RULES:
+            if rule_fn(fm, body):
+                report["fixes"].append(rule_name)
+
+        # share-url rule needs DB context
+        if rule_add_share_url(fm, body, db_share_url):
+            report["fixes"].append("add_share_url")
+
+        # Determine target path
+        target_dir = OBSIDIAN_CLIPPINGS
+        target_path = os.path.join(target_dir, os.path.basename(note_path))
+        needs_move = os.path.abspath(note_path) != os.path.abspath(target_path)
+
+        if needs_move:
+            report["moved"] = True
+
+        # Register in DB if orphaned
+        if not db_row:
+            report["registered"] = True
+
+        if not apply:
+            return report
+
+        # Apply: write normalized content
+        if report["fixes"]:
+            new_content = serialize_frontmatter(fm) + "\n" + body
+            with open(note_path, "w", encoding="utf-8") as f:
+                f.write(new_content)
+
+        # Apply: move to canonical directory
+        if needs_move:
+            os.makedirs(target_dir, exist_ok=True)
+            # Handle filename collision
+            if os.path.exists(target_path) and os.path.abspath(note_path) != os.path.abspath(target_path):
+                base, ext = os.path.splitext(os.path.basename(note_path))
+                counter = 1
+                while os.path.exists(target_path):
+                    target_path = os.path.join(target_dir, f"{base} ({counter}){ext}")
+                    counter += 1
+            shutil.move(note_path, target_path)
+            note_path = target_path
+
+        # Apply: register in DB
+        if report["registered"]:
+            content_type = fm.get("content-type")
+            if not content_type and source_url:
+                content_type = classify_url(source_url)
+            sender = fm.get("sender")
+            metadata_dict = {}
+            if fm.get("creator"):
+                metadata_dict["creator"] = fm["creator"]
+            if fm.get("platform"):
+                metadata_dict["platform"] = fm["platform"]
+            if fm.get("published"):
+                metadata_dict["upload_date"] = fm["published"].replace("-", "")
+
+            try:
+                link_id = add_link(
+                    url=source_url,
+                    source_type="imported",
+                    sender=sender,
+                    content_type=content_type,
+                    metadata=json.dumps(metadata_dict) if metadata_dict else None,
+                    db_path=db_path,
+                )
+                # Set status to summarized (note already exists) and record note path
+                update_status(
+                    link_id=link_id,
+                    status="summarized",
+                    obsidian_note_path=note_path,
+                    db_path=db_path,
+                )
+                logger.info("Registered in DB: %s (id=%d)", source_url, link_id)
+            except sqlite3.IntegrityError:
+                logger.info("URL already in DB: %s", source_url)
+
+        # Apply: update obsidian_note_path in DB if it changed
+        elif db_row and needs_move:
+            update_status(
+                link_id=db_row["id"],
+                status=db_row["status"],
+                obsidian_note_path=note_path,
+                db_path=db_path,
+            )
+
+    except Exception as e:
+        report["error"] = str(e)
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Sync Obsidian clippings with Crow's Nest database and spec."
+    )
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Apply changes (default is dry-run).",
+    )
+    parser.add_argument(
+        "--scan-dir", action="append", dest="scan_dirs", metavar="PATH",
+        help="Directory to scan (can be specified multiple times). "
+             "Defaults to legacy + current clippings dirs.",
+    )
+    parser.add_argument(
+        "--db", default=DB_PATH, metavar="PATH",
+        help=f"Database path (default: {DB_PATH})",
+    )
+    args = parser.parse_args()
+
+    # Default scan dirs: both old and new locations
+    scan_dirs = args.scan_dirs or [LEGACY_CLIPPINGS_DIR, OBSIDIAN_CLIPPINGS]
+    # Deduplicate and filter to existing dirs
+    scan_dirs = list(dict.fromkeys(d for d in scan_dirs if os.path.isdir(d)))
+
+    if not scan_dirs:
+        print("No valid scan directories found.")
+        return
+
+    init_db(args.db)
+    db_urls = get_db_urls(args.db)
+
+    print(f"Scanning {len(scan_dirs)} directory(ies)...")
+    for d in scan_dirs:
+        print(f"  {d}")
+    print()
+
+    notes = find_clipping_notes(scan_dirs)
+    print(f"Found {len(notes)} clipping note(s)")
+    print()
+
+    if not notes:
+        return
+
+    total_fixes = 0
+    total_registered = 0
+    total_moved = 0
+    total_errors = 0
+
+    for note_path in notes:
+        report = sync_note(note_path, db_urls, args.db, apply=args.apply)
+
+        # Print status
+        actions = []
+        if report["fixes"]:
+            actions.append(f"fix: {', '.join(report['fixes'])}")
+        if report["registered"]:
+            actions.append("register in DB")
+        if report["moved"]:
+            actions.append("move")
+        if report["error"]:
+            actions.append(f"ERROR: {report['error']}")
+
+        if actions:
+            prefix = "APPLY" if args.apply else "WOULD"
+            print(f"  [{prefix}] {report['filename']}")
+            for a in actions:
+                print(f"    -> {a}")
+
+        total_fixes += len(report["fixes"])
+        total_registered += 1 if report["registered"] else 0
+        total_moved += 1 if report["moved"] else 0
+        total_errors += 1 if report["error"] else 0
+
+    print()
+    mode = "Applied" if args.apply else "Dry run"
+    print(f"{mode} summary:")
+    print(f"  Notes scanned:  {len(notes)}")
+    print(f"  Fixes needed:   {total_fixes}")
+    print(f"  DB registrations: {total_registered}")
+    print(f"  Notes to move:  {total_moved}")
+    print(f"  Errors:         {total_errors}")
+
+    if not args.apply and (total_fixes or total_registered or total_moved):
+        print()
+        print("Re-run with --apply to execute changes.")
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, os.path.dirname(__file__))
+    main()

--- a/tests/test_config_paths.py
+++ b/tests/test_config_paths.py
@@ -5,5 +5,5 @@ from pipeline.config import OBSIDIAN_CLIPPINGS
 def test_clippings_path_points_to_areas():
     """Clippings should write to AREAS, not INBOX."""
     assert "2 - AREAS" in OBSIDIAN_CLIPPINGS
-    assert "CLIPPINGS - Need Sorting" in OBSIDIAN_CLIPPINGS
+    assert "INTERNET CLIPPINGS" in OBSIDIAN_CLIPPINGS
     assert "0 - INBOX" not in OBSIDIAN_CLIPPINGS


### PR DESCRIPTION
## Summary

- Rewrite archiver to upload individual media files (not tar.gz) to R2 with Content-Type headers for inline browser playback
- Generate share URLs via `share.bymarkriechers.com` and write them to the DB and Obsidian notes
- Save web pages to Readwise Reader with the Reader URL stored in the note and DB
- Add `share_url` column to the database with migration support
- Rename clippings output directory from `CLIPPINGS - Need Sorting` to `INTERNET CLIPPINGS`
- Add `sync_clippings.py` — reusable, idempotent tool to normalize Obsidian clippings against the current pipeline spec with rule-based normalization
- Support images and audio (podcast) in addition to video for R2 archival

## Migration performed

- 90 items fully archived (80 with share URLs, 10 YouTube/image items pending backfill)
- 72 orphaned Obsidian notes from the old pipeline imported into the database
- All notes moved to `INTERNET CLIPPINGS/` with normalized metadata
- R2 credentials corrected (endpoint URL typo, rotated secret key)
- Frontmatter corruption from initial archiver bug identified and fixed across 17 notes

## Related issues

- Filed #47 (duplicate notes on re-processing)
- Filed #48 (configurable batch sizes)
- Filed #49 (stale test expectations)
- Updated #44 (Signal re-registration status)
- Updated #27 (YouTube backfill status)

## Test plan

- [x] `pytest tests/pipeline/test_archiver_credentials.py` — 4/4 passing
- [x] `pytest tests/test_config_paths.py` — passing with updated path
- [x] `sync_clippings.py --apply` — 91 notes scanned, 72 registered, 90 moved
- [x] Idempotency: re-run reports 0 fixes, 0 registrations
- [x] Share URL verified: `curl -I https://share.bymarkriechers.com/2026/04/ralph-loop-explained-with-pretty-boxes.mp4` returns HTTP 200 with `video/mp4`
- [x] Readwise save verified: 6 web pages saved with Reader URLs in notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)