### PR TITLE
feat: multi-input intake via Cloudflare Worker, Obsidian scanner, iMessage

### DIFF
--- a/config/launchd/com.crows-nest.imessage-listener.plist
+++ b/config/launchd/com.crows-nest.imessage-listener.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.crows-nest.imessage-listener</string>
+
+    <key>Comment</key>
+    <string>Poll iMessage for self-sent URLs every 5 minutes</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/PATH/TO/crows-nest/.venv/bin/python</string>
+        <string>/PATH/TO/crows-nest/pipeline/imessage_listener.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/PATH/TO/crows-nest/pipeline</string>
+
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>StandardOutPath</key>
+    <string>/PATH/TO/crows-nest/logs/launchd-imessage-listener.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/PATH/TO/crows-nest/logs/launchd-imessage-listener.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/config/launchd/com.crows-nest.ingest-poller.plist
+++ b/config/launchd/com.crows-nest.ingest-poller.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.crows-nest.ingest-poller</string>
+
+    <key>Comment</key>
+    <string>Poll Cloudflare D1 ingest queue every 5 minutes and drain into local pipeline</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/PATH/TO/crows-nest/.venv/bin/python</string>
+        <string>/PATH/TO/crows-nest/pipeline/ingest_poller.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/PATH/TO/crows-nest/pipeline</string>
+
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>StandardOutPath</key>
+    <string>/PATH/TO/crows-nest/logs/launchd-ingest-poller.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/PATH/TO/crows-nest/logs/launchd-ingest-poller.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/config/launchd/com.crows-nest.obsidian-scanner.plist
+++ b/config/launchd/com.crows-nest.obsidian-scanner.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.crows-nest.obsidian-scanner</string>
+
+    <key>Comment</key>
+    <string>Scan Obsidian vault for pending-clippings notes every 5 minutes</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/PATH/TO/crows-nest/.venv/bin/python</string>
+        <string>/PATH/TO/crows-nest/pipeline/obsidian_scanner.py</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/PATH/TO/crows-nest/pipeline</string>
+
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>StandardOutPath</key>
+    <string>/PATH/TO/crows-nest/logs/launchd-obsidian-scanner.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/PATH/TO/crows-nest/logs/launchd-obsidian-scanner.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -57,6 +57,16 @@ OBSIDIAN_ARCHIVE = os.path.join(OBSIDIAN_VAULT, "4 - ARCHIVE")
 
 
 # ---------------------------------------------------------------------------
+# Ingest API (Cloudflare Worker + D1 queue)
+# ---------------------------------------------------------------------------
+
+INGEST_API_URL = os.environ.get(
+    "CROWS_NEST_INGEST_API_URL",
+    "https://share.bymarkriechers.com/api",
+)
+
+
+# ---------------------------------------------------------------------------
 # Image processing — platform-adaptive
 # ---------------------------------------------------------------------------
 

--- a/pipeline/imessage_listener.py
+++ b/pipeline/imessage_listener.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+iMessage self-message listener for the Crow's Nest pipeline.
+
+Polls the local iMessage database for messages sent by yourself (is_from_me=1)
+in direct conversations (not groups) that contain URLs. Ingests new URLs
+via add_link() and tracks the last-seen ROWID to avoid reprocessing.
+
+Usage: text yourself a URL from any device — the pipeline picks it up.
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from config import DATA_DIR
+from content_types import classify_url
+from db import DB_PATH, add_link, init_db
+from utils import extract_urls, setup_logging
+
+logger = setup_logging("crows-nest.imessage-listener")
+
+IMESSAGE_DB = os.path.expanduser("~/Library/Messages/chat.db")
+STATE_FILE = os.path.join(DATA_DIR, "imessage_state.json")
+
+
+def _load_state(state_file: str) -> int:
+    """Load the last-seen ROWID from state file. Returns 0 if no state."""
+    try:
+        with open(state_file, "r") as f:
+            return json.load(f).get("last_rowid", 0)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return 0
+
+
+def _save_state(state_file: str, last_rowid: int) -> None:
+    """Save the last-seen ROWID to state file."""
+    os.makedirs(os.path.dirname(state_file), exist_ok=True)
+    with open(state_file, "w") as f:
+        json.dump({"last_rowid": last_rowid}, f)
+
+
+def fetch_self_messages(imessage_db: str, since_rowid: int = 0) -> list[dict]:
+    """Fetch self-sent direct messages with URLs since the given ROWID."""
+    try:
+        conn = sqlite3.connect(f"file:{imessage_db}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+    except sqlite3.OperationalError as exc:
+        logger.error("Cannot open iMessage DB: %s", exc)
+        return []
+
+    try:
+        cursor = conn.execute(
+            """
+            SELECT ROWID, text
+            FROM message
+            WHERE is_from_me = 1
+              AND cache_roomnames IS NULL
+              AND text LIKE '%http%'
+              AND ROWID > ?
+            ORDER BY ROWID ASC
+            LIMIT 100
+            """,
+            (since_rowid,),
+        )
+        return [{"rowid": row["ROWID"], "text": row["text"]} for row in cursor.fetchall()]
+    except sqlite3.OperationalError as exc:
+        logger.error("Failed to query iMessage DB: %s", exc)
+        return []
+    finally:
+        conn.close()
+
+
+def process_self_messages(
+    imessage_db: str = IMESSAGE_DB,
+    db_path: str = DB_PATH,
+    state_file: str = STATE_FILE,
+) -> int:
+    """Poll iMessage DB for self-sent URLs and ingest them.
+    Returns the number of new URLs added.
+    """
+    last_rowid = _load_state(state_file)
+    messages = fetch_self_messages(imessage_db, since_rowid=last_rowid)
+
+    if not messages:
+        return 0
+
+    init_db(db_path)
+    added = 0
+    max_rowid = last_rowid
+
+    for msg in messages:
+        urls = extract_urls(msg["text"])
+        for url in urls:
+            content_type = classify_url(url)
+            try:
+                add_link(
+                    url=url,
+                    source_type="imessage",
+                    sender=None,
+                    context=None,
+                    content_type=content_type,
+                    db_path=db_path,
+                )
+                added += 1
+                logger.info("Queued [%s]: %s", content_type, url)
+            except sqlite3.IntegrityError:
+                logger.info("Skipped duplicate: %s", url)
+
+        max_rowid = max(max_rowid, msg["rowid"])
+
+    _save_state(state_file, max_rowid)
+    return added
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Poll iMessage for self-sent URLs and ingest into the pipeline."
+    )
+    parser.add_argument("--db", default=DB_PATH, help="Path to pipeline SQLite database")
+    parser.add_argument("--imessage-db", default=IMESSAGE_DB, help="Path to iMessage chat.db")
+    parser.add_argument("--state-file", default=STATE_FILE, help="Path to state file")
+    args = parser.parse_args()
+
+    count = process_self_messages(args.imessage_db, args.db, args.state_file)
+    if count:
+        logger.info("Ingested %d new URL(s) from iMessage", count)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/ingest_poller.py
+++ b/pipeline/ingest_poller.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""
+Ingest poller for the Crow's Nest pipeline.
+
+Drains the D1 ingest queue (populated by the Cloudflare Worker) into the
+local pipeline database. Designed to run on a launchd timer every 5 minutes.
+
+Each cycle:
+  1. GET /api/pending — fetch unsynced items from D1
+  2. For each item, call add_link() to insert into local SQLite
+  3. POST /api/mark-synced — mark successfully processed items in D1
+
+Duplicates (URLs already in local DB) are skipped and marked synced so
+they don't reappear on the next poll.
+"""
+
+import argparse
+import sqlite3
+import sys
+import os
+
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from config import INGEST_API_URL
+from content_types import classify_url
+from db import DB_PATH, add_link, init_db
+from keychain_secrets import get_secret
+from utils import setup_logging
+
+logger = setup_logging("crows-nest.ingest-poller")
+
+
+def fetch_pending(api_url: str, token: str, limit: int = 50) -> list[dict]:
+    """Fetch unsynced items from the D1 ingest queue."""
+    try:
+        resp = requests.get(
+            f"{api_url}/pending",
+            headers={"Authorization": f"Bearer {token}"},
+            params={"limit": limit},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        return resp.json().get("items", [])
+    except Exception as exc:
+        logger.error("Failed to fetch pending items: %s", exc)
+        return []
+
+
+def mark_synced(api_url: str, token: str, ids: list[int]) -> bool:
+    """Mark items as synced in the D1 ingest queue."""
+    try:
+        resp = requests.post(
+            f"{api_url}/mark-synced",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"ids": ids},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        return True
+    except Exception as exc:
+        logger.error("Failed to mark synced: %s", exc)
+        return False
+
+
+def poll_and_drain(api_url: str, token: str, db_path: str = DB_PATH) -> int:
+    """Poll D1 queue and drain items into local pipeline DB.
+    Returns the number of new items added (excludes duplicates).
+    """
+    items = fetch_pending(api_url, token)
+    if not items:
+        return 0
+
+    init_db(db_path)
+    added = 0
+    processed_ids = []
+
+    for item in items:
+        url = item["url"]
+        content_type = classify_url(url)
+        try:
+            add_link(
+                url=url,
+                source_type="ingest-api",
+                sender=item.get("source", "shortcut"),
+                context=item.get("context"),
+                content_type=content_type,
+                db_path=db_path,
+            )
+            added += 1
+            logger.info("Queued [%s]: %s", content_type, url)
+        except sqlite3.IntegrityError:
+            logger.info("Skipped duplicate: %s", url)
+
+        processed_ids.append(item["id"])
+
+    if processed_ids:
+        mark_synced(api_url, token, processed_ids)
+
+    return added
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Poll the D1 ingest queue and drain into the local pipeline."
+    )
+    parser.add_argument("--db", default=DB_PATH, help="Path to local SQLite database")
+    parser.add_argument("--limit", type=int, default=50, help="Max items per poll")
+    args = parser.parse_args()
+
+    token = get_secret("CROWS_NEST_INGEST_TOKEN")
+    if not token:
+        logger.error("CROWS_NEST_INGEST_TOKEN not found in Keychain or env")
+        sys.exit(1)
+
+    count = poll_and_drain(INGEST_API_URL, token, db_path=args.db)
+    if count:
+        logger.info("Drained %d new item(s) from ingest queue", count)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/obsidian_scanner.py
+++ b/pipeline/obsidian_scanner.py
@@ -4,7 +4,7 @@ Obsidian vault scanner for the Crow's Nest pipeline.
 
 Scans the Obsidian vault for notes tagged with 'pending-clippings',
 extracts URLs from the note body, ingests them via add_link(), and
-deletes the note once all URLs are processed.
+archives the note to 4 - ARCHIVE/ once all URLs are processed.
 
 This provides an offline-first fallback: just write URLs into a note
 and the pipeline picks them up on the next scan cycle.
@@ -18,6 +18,8 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+import shutil
+
 from config import OBSIDIAN_VAULT
 from content_types import classify_url
 from db import DB_PATH, add_link, init_db
@@ -27,6 +29,15 @@ logger = setup_logging("crows-nest.obsidian-scanner")
 
 _TAG_PATTERN = re.compile(r"pending-clippings")
 _FRONTMATTER_PATTERN = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+def _archive_note(note_path: str, vault_path: str) -> None:
+    """Move a processed note to the vault's archive directory."""
+    archive_dir = os.path.join(vault_path, "4 - ARCHIVE", "processed-clippings")
+    os.makedirs(archive_dir, exist_ok=True)
+    dest = os.path.join(archive_dir, os.path.basename(note_path))
+    shutil.move(note_path, dest)
+    logger.info("Archived note to %s", dest)
 
 
 def find_pending_notes(vault_path: str) -> list[str]:
@@ -85,8 +96,8 @@ def scan_and_ingest(vault_path: str, db_path: str = DB_PATH) -> int:
 
         urls = extract_urls_from_note(content)
         if not urls:
-            logger.info("No URLs in %s, deleting empty note", os.path.basename(note_path))
-            os.remove(note_path)
+            logger.info("No URLs in %s, archiving empty note", os.path.basename(note_path))
+            _archive_note(note_path, vault_path)
             continue
 
         added = 0
@@ -106,8 +117,8 @@ def scan_and_ingest(vault_path: str, db_path: str = DB_PATH) -> int:
             except sqlite3.IntegrityError:
                 logger.info("Skipped duplicate: %s", url)
 
-        os.remove(note_path)
-        logger.info("Deleted note: %s (%d new, %d total URLs)", os.path.basename(note_path), added, len(urls))
+        _archive_note(note_path, vault_path)
+        logger.info("Processed note: %s (%d new, %d total URLs)", os.path.basename(note_path), added, len(urls))
         total_added += added
 
     return total_added

--- a/pipeline/obsidian_scanner.py
+++ b/pipeline/obsidian_scanner.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Obsidian vault scanner for the Crow's Nest pipeline.
+
+Scans the Obsidian vault for notes tagged with 'pending-clippings',
+extracts URLs from the note body, ingests them via add_link(), and
+deletes the note once all URLs are processed.
+
+This provides an offline-first fallback: just write URLs into a note
+and the pipeline picks them up on the next scan cycle.
+"""
+
+import argparse
+import os
+import re
+import sqlite3
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from config import OBSIDIAN_VAULT
+from content_types import classify_url
+from db import DB_PATH, add_link, init_db
+from utils import extract_urls, setup_logging
+
+logger = setup_logging("crows-nest.obsidian-scanner")
+
+_TAG_PATTERN = re.compile(r"pending-clippings")
+_FRONTMATTER_PATTERN = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+def find_pending_notes(vault_path: str) -> list[str]:
+    """Find all .md files in the vault with 'pending-clippings' in their frontmatter tags."""
+    results = []
+    for root, _dirs, files in os.walk(vault_path):
+        for fname in files:
+            if not fname.endswith(".md"):
+                continue
+            filepath = os.path.join(root, fname)
+            try:
+                with open(filepath, "r", encoding="utf-8") as f:
+                    content = f.read(2048)
+            except OSError:
+                continue
+
+            fm_match = _FRONTMATTER_PATTERN.match(content)
+            if not fm_match:
+                continue
+
+            frontmatter = fm_match.group(1)
+            if _TAG_PATTERN.search(frontmatter):
+                results.append(filepath)
+
+    return results
+
+
+def extract_urls_from_note(content: str) -> list[str]:
+    """Extract URLs from note body, skipping the frontmatter block."""
+    fm_match = _FRONTMATTER_PATTERN.match(content)
+    if fm_match:
+        body = content[fm_match.end():]
+    else:
+        body = content
+    return extract_urls(body)
+
+
+def scan_and_ingest(vault_path: str, db_path: str = DB_PATH) -> int:
+    """Scan vault for pending-clippings notes, ingest URLs, delete notes.
+    Returns the number of new URLs added (excludes duplicates).
+    """
+    notes = find_pending_notes(vault_path)
+    if not notes:
+        return 0
+
+    init_db(db_path)
+    total_added = 0
+
+    for note_path in notes:
+        try:
+            with open(note_path, "r", encoding="utf-8") as f:
+                content = f.read()
+        except OSError as exc:
+            logger.error("Could not read %s: %s", note_path, exc)
+            continue
+
+        urls = extract_urls_from_note(content)
+        if not urls:
+            logger.info("No URLs in %s, deleting empty note", os.path.basename(note_path))
+            os.remove(note_path)
+            continue
+
+        added = 0
+        for url in urls:
+            content_type = classify_url(url)
+            try:
+                add_link(
+                    url=url,
+                    source_type="obsidian",
+                    sender=None,
+                    context=os.path.basename(note_path),
+                    content_type=content_type,
+                    db_path=db_path,
+                )
+                added += 1
+                logger.info("Queued [%s]: %s", content_type, url)
+            except sqlite3.IntegrityError:
+                logger.info("Skipped duplicate: %s", url)
+
+        os.remove(note_path)
+        logger.info("Deleted note: %s (%d new, %d total URLs)", os.path.basename(note_path), added, len(urls))
+        total_added += added
+
+    return total_added
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scan Obsidian vault for pending-clippings notes and ingest URLs."
+    )
+    parser.add_argument("--vault", default=OBSIDIAN_VAULT, help="Path to Obsidian vault")
+    parser.add_argument("--db", default=DB_PATH, help="Path to local SQLite database")
+    args = parser.parse_args()
+
+    count = scan_and_ingest(args.vault, db_path=args.db)
+    if count:
+        logger.info("Ingested %d new URL(s) from vault notes", count)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/status.py
+++ b/pipeline/status.py
@@ -142,6 +142,18 @@ PIPELINE_JOBS = {
         "log": os.path.join(LOG_DIR, "launchd-crows-nest-archiver.log"),
         "max_stale_minutes": 1500,   # runs daily at 3 AM
     },
+    "ingest_poller.py": {
+        "log": os.path.join(LOG_DIR, "launchd-ingest-poller.log"),
+        "max_stale_minutes": 15,     # runs every 5 min
+    },
+    "obsidian_scanner.py": {
+        "log": os.path.join(LOG_DIR, "launchd-obsidian-scanner.log"),
+        "max_stale_minutes": 15,     # runs every 5 min
+    },
+    "imessage_listener.py": {
+        "log": os.path.join(LOG_DIR, "launchd-imessage-listener.log"),
+        "max_stale_minutes": 15,     # runs every 5 min
+    },
 }
 
 
@@ -270,6 +282,45 @@ def print_health() -> bool:
     return all_ok
 
 
+def print_sources(db_path: str, days: int = 7) -> None:
+    """Print a breakdown of links by source_type for the last N days."""
+    init_db(db_path)
+    conn = get_connection(db_path)
+    try:
+        cursor = conn.execute(
+            """
+            SELECT source_type, COUNT(*) AS cnt
+            FROM links
+            WHERE created_at >= datetime('now', ?)
+            GROUP BY source_type
+            ORDER BY cnt DESC
+            """,
+            (f"-{days} days",),
+        )
+        rows = cursor.fetchall()
+
+        print()
+        print(f"CROW'S NEST — Sources (last {days} days)")
+        print("=" * 40)
+        print()
+
+        if rows:
+            total = sum(row["cnt"] for row in rows)
+            for row in rows:
+                source = row["source_type"] or "unknown"
+                cnt = row["cnt"]
+                bar = "█" * min(cnt, 30)
+                print(f"  {source:<16} {cnt:>4}  {bar}")
+            print()
+            print(f"  {'TOTAL':<16} {total:>4}")
+        else:
+            print("  (no links in this period)")
+        print()
+
+    finally:
+        conn.close()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Crow's Nest pipeline status dashboard"
@@ -284,11 +335,20 @@ def main() -> None:
         action="store_true",
         help="Run health checks and exit with code 0 (healthy) or 1 (problems)",
     )
+    parser.add_argument(
+        "--sources",
+        action="store_true",
+        help="Show breakdown of links by source type for the last 7 days",
+    )
     args = parser.parse_args()
 
     if args.health:
         healthy = print_health()
         sys.exit(0 if healthy else 1)
+
+    if args.sources:
+        print_sources(args.db)
+        return
 
     print_dashboard(args.db)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.11"
 dependencies = [
     "mcp[cli]>=1.0",
     "thefuzz[speedup]",
+    "requests>=2.31",
 ]
 
 [project.scripts]
@@ -13,9 +14,9 @@ mcp-knowledge-server = "mcp_knowledge.server:main"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "httpx>=0.24"]
-archive = ["boto3>=1.28", "requests>=2.31"]
+archive = ["boto3>=1.28"]
 semantic = ["chromadb>=0.5", "fastembed>=0.3"]
-rss = ["feedparser>=6.0", "requests>=2.31"]
+rss = ["feedparser>=6.0"]
 all = ["crows-nest[archive,semantic,rss]"]
 
 [tool.hatch.build.targets.wheel]

--- a/tests/pipeline/test_imessage_listener.py
+++ b/tests/pipeline/test_imessage_listener.py
@@ -1,0 +1,117 @@
+# tests/pipeline/test_imessage_listener.py
+"""Tests for the iMessage self-message listener."""
+
+import os
+import sqlite3
+import sys
+import textwrap
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../pipeline"))
+
+
+def _create_mock_imessage_db(db_path: str, messages: list[dict]) -> None:
+    """Create a minimal iMessage-like DB with test messages."""
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+        CREATE TABLE message (
+            ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+            text TEXT,
+            is_from_me INTEGER DEFAULT 0,
+            date INTEGER,
+            cache_roomnames TEXT
+        )
+    """)
+    for msg in messages:
+        conn.execute(
+            "INSERT INTO message (text, is_from_me, date, cache_roomnames) VALUES (?, ?, ?, ?)",
+            (msg.get("text"), msg.get("is_from_me", 1), msg.get("date", 0), msg.get("cache_roomnames")),
+        )
+    conn.commit()
+    conn.close()
+
+
+class TestFetchSelfMessages:
+    def test_finds_self_sent_urls(self, tmp_path):
+        from imessage_listener import fetch_self_messages
+
+        imsg_db = str(tmp_path / "chat.db")
+        _create_mock_imessage_db(imsg_db, [
+            {"text": "https://example.com/cool", "is_from_me": 1, "date": 100},
+            {"text": "Hey what's up", "is_from_me": 1, "date": 200},
+            {"text": "https://tiktok.com/t/abc", "is_from_me": 0, "date": 300},
+        ])
+
+        results = fetch_self_messages(imsg_db, since_rowid=0)
+        assert len(results) == 1
+        assert results[0]["text"] == "https://example.com/cool"
+
+    def test_respects_since_rowid(self, tmp_path):
+        from imessage_listener import fetch_self_messages
+
+        imsg_db = str(tmp_path / "chat.db")
+        _create_mock_imessage_db(imsg_db, [
+            {"text": "https://example.com/old", "is_from_me": 1, "date": 100},
+            {"text": "https://example.com/new", "is_from_me": 1, "date": 200},
+        ])
+
+        results = fetch_self_messages(imsg_db, since_rowid=1)
+        assert len(results) == 1
+        assert results[0]["text"] == "https://example.com/new"
+
+    def test_skips_group_messages(self, tmp_path):
+        from imessage_listener import fetch_self_messages
+
+        imsg_db = str(tmp_path / "chat.db")
+        _create_mock_imessage_db(imsg_db, [
+            {"text": "https://example.com/group", "is_from_me": 1, "date": 100, "cache_roomnames": "chat123"},
+            {"text": "https://example.com/direct", "is_from_me": 1, "date": 200, "cache_roomnames": None},
+        ])
+
+        results = fetch_self_messages(imsg_db, since_rowid=0)
+        assert len(results) == 1
+        assert "direct" in results[0]["text"]
+
+
+class TestProcessSelfMessages:
+    def test_ingests_urls_from_self_messages(self, tmp_path):
+        from imessage_listener import process_self_messages
+        from db import init_db, get_connection
+
+        pipeline_db = str(tmp_path / "pipeline.db")
+        init_db(pipeline_db)
+
+        imsg_db = str(tmp_path / "chat.db")
+        _create_mock_imessage_db(imsg_db, [
+            {"text": "https://example.com/save-this", "is_from_me": 1, "date": 100},
+            {"text": "check this out https://youtu.be/xyz and also https://tiktok.com/t/abc", "is_from_me": 1, "date": 200},
+        ])
+
+        state_file = str(tmp_path / "imessage_state.json")
+        count = process_self_messages(imsg_db, pipeline_db, state_file)
+        assert count == 3
+
+        conn = get_connection(pipeline_db)
+        rows = conn.execute("SELECT url, source_type FROM links ORDER BY id").fetchall()
+        conn.close()
+        assert len(rows) == 3
+        assert all(r["source_type"] == "imessage" for r in rows)
+
+    def test_remembers_last_rowid(self, tmp_path):
+        from imessage_listener import process_self_messages
+        from db import init_db
+
+        pipeline_db = str(tmp_path / "pipeline.db")
+        init_db(pipeline_db)
+
+        imsg_db = str(tmp_path / "chat.db")
+        _create_mock_imessage_db(imsg_db, [
+            {"text": "https://example.com/first", "is_from_me": 1, "date": 100},
+        ])
+
+        state_file = str(tmp_path / "imessage_state.json")
+
+        count1 = process_self_messages(imsg_db, pipeline_db, state_file)
+        assert count1 == 1
+
+        count2 = process_self_messages(imsg_db, pipeline_db, state_file)
+        assert count2 == 0

--- a/tests/pipeline/test_ingest_poller.py
+++ b/tests/pipeline/test_ingest_poller.py
@@ -1,0 +1,119 @@
+"""Tests for the ingest poller that drains the D1 queue into the local pipeline."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../pipeline"))
+
+
+class FakeResponse:
+    """Minimal requests.Response stand-in."""
+
+    def __init__(self, json_data, status_code=200):
+        self._json = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception(f"HTTP {self.status_code}")
+
+
+class TestFetchPending:
+    @patch("ingest_poller.requests.get")
+    def test_returns_items(self, mock_get):
+        from ingest_poller import fetch_pending
+        mock_get.return_value = FakeResponse({
+            "items": [
+                {"id": 1, "url": "https://example.com/a", "context": None, "source": "shortcut", "created_at": "2026-04-06T12:00:00Z"},
+                {"id": 2, "url": "https://example.com/b", "context": "cool thing", "source": "shortcut", "created_at": "2026-04-06T12:01:00Z"},
+            ]
+        })
+        items = fetch_pending("https://test.api/api", "fake-token")
+        assert len(items) == 2
+        assert items[0]["url"] == "https://example.com/a"
+        assert items[1]["context"] == "cool thing"
+        mock_get.assert_called_once()
+        call_args = mock_get.call_args
+        assert "Bearer fake-token" in call_args.kwargs.get("headers", {}).get("Authorization", "")
+
+    @patch("ingest_poller.requests.get")
+    def test_returns_empty_list_on_no_items(self, mock_get):
+        from ingest_poller import fetch_pending
+        mock_get.return_value = FakeResponse({"items": []})
+        items = fetch_pending("https://test.api/api", "fake-token")
+        assert items == []
+
+    @patch("ingest_poller.requests.get")
+    def test_returns_empty_list_on_http_error(self, mock_get):
+        from ingest_poller import fetch_pending
+        mock_get.return_value = FakeResponse({"error": "unauthorized"}, status_code=401)
+        items = fetch_pending("https://test.api/api", "fake-token")
+        assert items == []
+
+
+class TestMarkSynced:
+    @patch("ingest_poller.requests.post")
+    def test_marks_ids(self, mock_post):
+        from ingest_poller import mark_synced
+        mock_post.return_value = FakeResponse({"synced": 2})
+        result = mark_synced("https://test.api/api", "fake-token", [1, 2])
+        assert result is True
+        call_args = mock_post.call_args
+        body = call_args.kwargs.get("json", {})
+        assert body["ids"] == [1, 2]
+
+    @patch("ingest_poller.requests.post")
+    def test_returns_false_on_error(self, mock_post):
+        from ingest_poller import mark_synced
+        mock_post.return_value = FakeResponse({"error": "fail"}, status_code=500)
+        result = mark_synced("https://test.api/api", "fake-token", [1])
+        assert result is False
+
+
+class TestPollAndDrain:
+    @patch("ingest_poller.mark_synced")
+    @patch("ingest_poller.add_link")
+    @patch("ingest_poller.fetch_pending")
+    def test_drains_items_into_local_db(self, mock_fetch, mock_add_link, mock_mark):
+        from ingest_poller import poll_and_drain
+        mock_fetch.return_value = [
+            {"id": 10, "url": "https://example.com/vid", "context": "test", "source": "shortcut", "created_at": "2026-04-06T12:00:00Z"},
+        ]
+        mock_add_link.return_value = 42
+        mock_mark.return_value = True
+        result = poll_and_drain("https://test.api/api", "fake-token", db_path=":memory:")
+        assert result == 1
+        mock_add_link.assert_called_once()
+        call_kwargs = mock_add_link.call_args.kwargs
+        assert call_kwargs["url"] == "https://example.com/vid"
+        assert call_kwargs["source_type"] == "ingest-api"
+        assert call_kwargs["context"] == "test"
+        mock_mark.assert_called_once_with("https://test.api/api", "fake-token", [10])
+
+    @patch("ingest_poller.mark_synced")
+    @patch("ingest_poller.add_link")
+    @patch("ingest_poller.fetch_pending")
+    def test_skips_duplicate_urls(self, mock_fetch, mock_add_link, mock_mark):
+        import sqlite3
+        from ingest_poller import poll_and_drain
+        mock_fetch.return_value = [
+            {"id": 20, "url": "https://example.com/dupe", "context": None, "source": "shortcut", "created_at": "2026-04-06T12:00:00Z"},
+        ]
+        mock_add_link.side_effect = sqlite3.IntegrityError("UNIQUE constraint")
+        mock_mark.return_value = True
+        result = poll_and_drain("https://test.api/api", "fake-token", db_path=":memory:")
+        assert result == 0
+        mock_mark.assert_called_once_with("https://test.api/api", "fake-token", [20])
+
+    @patch("ingest_poller.fetch_pending")
+    def test_noop_when_queue_empty(self, mock_fetch):
+        from ingest_poller import poll_and_drain
+        mock_fetch.return_value = []
+        result = poll_and_drain("https://test.api/api", "fake-token", db_path=":memory:")
+        assert result == 0

--- a/tests/pipeline/test_obsidian_scanner.py
+++ b/tests/pipeline/test_obsidian_scanner.py
@@ -115,7 +115,7 @@ class TestExtractUrlsFromNote:
 class TestScanAndIngest:
     """Test the main scan_and_ingest orchestration."""
 
-    def test_ingests_urls_and_deletes_note(self, tmp_path):
+    def test_ingests_urls_and_archives_note(self, tmp_path):
         from obsidian_scanner import scan_and_ingest
         from db import init_db, get_connection
 
@@ -137,8 +137,10 @@ class TestScanAndIngest:
         count = scan_and_ingest(str(vault_dir), db_path=db_path)
         assert count == 2
 
-        # Note should be deleted
+        # Note should be moved to archive, not at original location
         assert not note.exists()
+        archived = vault_dir / "4 - ARCHIVE" / "processed-clippings" / "saved-links.md"
+        assert archived.exists()
 
         # URLs should be in the DB
         conn = get_connection(db_path)
@@ -149,7 +151,7 @@ class TestScanAndIngest:
         assert rows[0]["source_type"] == "obsidian"
         assert rows[1]["url"] == "https://youtu.be/abc123"
 
-    def test_skips_duplicates_still_deletes_note(self, tmp_path):
+    def test_skips_duplicates_still_archives_note(self, tmp_path):
         from obsidian_scanner import scan_and_ingest
         from db import init_db, add_link
 
@@ -170,7 +172,9 @@ class TestScanAndIngest:
 
         count = scan_and_ingest(str(vault_dir), db_path=db_path)
         assert count == 0  # dupe not counted
-        assert not note.exists()  # note still deleted
+        assert not note.exists()  # note moved from original location
+        archived = vault_dir / "4 - ARCHIVE" / "processed-clippings" / "links.md"
+        assert archived.exists()  # note archived
 
     def test_noop_when_no_pending_notes(self, tmp_path):
         from obsidian_scanner import scan_and_ingest

--- a/tests/pipeline/test_obsidian_scanner.py
+++ b/tests/pipeline/test_obsidian_scanner.py
@@ -1,0 +1,183 @@
+# tests/pipeline/test_obsidian_scanner.py
+"""Tests for the Obsidian vault scanner that ingests links from pending-clippings notes."""
+
+import os
+import sqlite3
+import sys
+import textwrap
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../pipeline"))
+
+
+class TestFindPendingNotes:
+    """Test finding notes tagged with pending-clippings."""
+
+    def test_finds_tagged_note(self, tmp_path):
+        from obsidian_scanner import find_pending_notes
+
+        note = tmp_path / "links.md"
+        note.write_text(textwrap.dedent("""\
+            ---
+            tags:
+              - pending-clippings
+            ---
+            https://example.com/a
+        """))
+
+        results = find_pending_notes(str(tmp_path))
+        assert len(results) == 1
+        assert results[0] == str(note)
+
+    def test_skips_note_without_tag(self, tmp_path):
+        from obsidian_scanner import find_pending_notes
+
+        note = tmp_path / "other.md"
+        note.write_text(textwrap.dedent("""\
+            ---
+            tags:
+              - journal
+            ---
+            Some text
+        """))
+
+        results = find_pending_notes(str(tmp_path))
+        assert results == []
+
+    def test_finds_multiple_notes(self, tmp_path):
+        from obsidian_scanner import find_pending_notes
+
+        for name in ("a.md", "b.md"):
+            (tmp_path / name).write_text(textwrap.dedent("""\
+                ---
+                tags:
+                  - pending-clippings
+                ---
+                https://example.com
+            """))
+
+        results = find_pending_notes(str(tmp_path))
+        assert len(results) == 2
+
+    def test_handles_inline_tag_format(self, tmp_path):
+        from obsidian_scanner import find_pending_notes
+
+        note = tmp_path / "inline.md"
+        note.write_text(textwrap.dedent("""\
+            ---
+            tags: [all, pending-clippings]
+            ---
+            https://example.com
+        """))
+
+        results = find_pending_notes(str(tmp_path))
+        assert len(results) == 1
+
+
+class TestExtractUrlsFromNote:
+    """Test URL extraction from note body (excluding frontmatter)."""
+
+    def test_extracts_urls_from_body(self):
+        from obsidian_scanner import extract_urls_from_note
+
+        content = textwrap.dedent("""\
+            ---
+            tags:
+              - pending-clippings
+            ---
+            https://example.com/a
+            https://example.com/b
+            Some text without a URL
+            https://tiktok.com/t/abc123
+        """)
+
+        urls = extract_urls_from_note(content)
+        assert urls == [
+            "https://example.com/a",
+            "https://example.com/b",
+            "https://tiktok.com/t/abc123",
+        ]
+
+    def test_returns_empty_for_no_urls(self):
+        from obsidian_scanner import extract_urls_from_note
+
+        content = textwrap.dedent("""\
+            ---
+            tags:
+              - pending-clippings
+            ---
+            Just some text, no links here.
+        """)
+
+        urls = extract_urls_from_note(content)
+        assert urls == []
+
+
+class TestScanAndIngest:
+    """Test the main scan_and_ingest orchestration."""
+
+    def test_ingests_urls_and_deletes_note(self, tmp_path):
+        from obsidian_scanner import scan_and_ingest
+        from db import init_db, get_connection
+
+        db_path = str(tmp_path / "test.db")
+        init_db(db_path)
+
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        note = vault_dir / "saved-links.md"
+        note.write_text(textwrap.dedent("""\
+            ---
+            tags:
+              - pending-clippings
+            ---
+            https://example.com/article
+            https://youtu.be/abc123
+        """))
+
+        count = scan_and_ingest(str(vault_dir), db_path=db_path)
+        assert count == 2
+
+        # Note should be deleted
+        assert not note.exists()
+
+        # URLs should be in the DB
+        conn = get_connection(db_path)
+        rows = conn.execute("SELECT url, source_type FROM links ORDER BY id").fetchall()
+        conn.close()
+        assert len(rows) == 2
+        assert rows[0]["url"] == "https://example.com/article"
+        assert rows[0]["source_type"] == "obsidian"
+        assert rows[1]["url"] == "https://youtu.be/abc123"
+
+    def test_skips_duplicates_still_deletes_note(self, tmp_path):
+        from obsidian_scanner import scan_and_ingest
+        from db import init_db, add_link
+
+        db_path = str(tmp_path / "test.db")
+        init_db(db_path)
+        add_link(url="https://example.com/dupe", source_type="cli", db_path=db_path)
+
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+        note = vault_dir / "links.md"
+        note.write_text(textwrap.dedent("""\
+            ---
+            tags:
+              - pending-clippings
+            ---
+            https://example.com/dupe
+        """))
+
+        count = scan_and_ingest(str(vault_dir), db_path=db_path)
+        assert count == 0  # dupe not counted
+        assert not note.exists()  # note still deleted
+
+    def test_noop_when_no_pending_notes(self, tmp_path):
+        from obsidian_scanner import scan_and_ingest
+
+        db_path = str(tmp_path / "test.db")
+        vault_dir = tmp_path / "vault"
+        vault_dir.mkdir()
+
+        count = scan_and_ingest(str(vault_dir), db_path=db_path)
+        assert count == 0

--- a/tests/pipeline/test_status_sources.py
+++ b/tests/pipeline/test_status_sources.py
@@ -1,0 +1,39 @@
+"""Tests for the status.py --sources flag."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../pipeline"))
+
+
+def test_sources_breakdown(tmp_path, capsys):
+    from db import init_db, add_link
+    from status import print_sources
+
+    db_path = str(tmp_path / "test.db")
+    init_db(db_path)
+
+    for url_id, source in [("a", "signal"), ("b", "signal"), ("c", "ingest-api"), ("d", "obsidian"), ("e", "imessage")]:
+        add_link(url=f"https://example.com/{url_id}", source_type=source, db_path=db_path)
+
+    print_sources(db_path)
+    output = capsys.readouterr().out
+
+    assert "signal" in output
+    assert "ingest-api" in output
+    assert "obsidian" in output
+    assert "imessage" in output
+    assert "2" in output  # signal has 2
+
+
+def test_sources_empty_db(tmp_path, capsys):
+    from db import init_db
+    from status import print_sources
+
+    db_path = str(tmp_path / "test.db")
+    init_db(db_path)
+
+    print_sources(db_path)
+    output = capsys.readouterr().out
+
+    assert "no links in this period" in output

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "crows-nest-ingest",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4"
+  }
+}

--- a/worker/schema.sql
+++ b/worker/schema.sql
@@ -1,0 +1,14 @@
+-- Ingest queue: links land here from any intake channel,
+-- then get drained into the local pipeline DB by the poller.
+
+CREATE TABLE IF NOT EXISTS ingest_queue (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    url        TEXT    NOT NULL,
+    context    TEXT,
+    source     TEXT    NOT NULL DEFAULT 'shortcut',
+    created_at TEXT    NOT NULL,
+    synced     INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_queue_synced
+    ON ingest_queue(synced);

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,0 +1,125 @@
+// Ingest endpoint for the Crow's Nest pipeline.
+// Accepts URLs from iOS Shortcuts, browser extensions, etc.
+// Writes to D1 queue; local poller drains into pipeline DB.
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/api/health" && request.method === "GET") {
+      return Response.json({ status: "ok", service: "crows-nest-ingest" });
+    }
+
+    if (url.pathname === "/api/ingest" && request.method === "POST") {
+      return handleIngest(request, env);
+    }
+
+    if (url.pathname === "/api/pending" && request.method === "GET") {
+      return handlePending(request, env);
+    }
+
+    if (url.pathname === "/api/mark-synced" && request.method === "POST") {
+      return handleMarkSynced(request, env);
+    }
+
+    // Everything else: not handled by this Worker (falls through to R2)
+    return fetch(request);
+  },
+};
+
+function authenticate(request, env) {
+  const header = request.headers.get("Authorization") || "";
+  const token = header.replace(/^Bearer\s+/i, "");
+  return token && token === env.INGEST_TOKEN;
+}
+
+async function handleIngest(request, env) {
+  if (!authenticate(request, env)) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  const linkUrl = (body.url || "").trim();
+  if (!linkUrl) {
+    return Response.json({ error: "url is required" }, { status: 400 });
+  }
+
+  try {
+    new URL(linkUrl);
+  } catch {
+    return Response.json({ error: "invalid url" }, { status: 400 });
+  }
+
+  const context = (body.context || "").trim() || null;
+  const source = (body.source || "shortcut").trim();
+  const now = new Date().toISOString();
+
+  try {
+    const result = await env.DB.prepare(
+      "INSERT INTO ingest_queue (url, context, source, created_at) VALUES (?, ?, ?, ?)"
+    )
+      .bind(linkUrl, context, source, now)
+      .run();
+
+    return Response.json({
+      id: result.meta.last_row_id,
+      status: "queued",
+      url: linkUrl,
+    });
+  } catch (err) {
+    return Response.json(
+      { error: "queue insert failed", detail: err.message },
+      { status: 500 }
+    );
+  }
+}
+
+async function handlePending(request, env) {
+  if (!authenticate(request, env)) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const limit = Math.min(
+    parseInt(new URL(request.url).searchParams.get("limit") || "50", 10),
+    200
+  );
+
+  const { results } = await env.DB.prepare(
+    "SELECT id, url, context, source, created_at FROM ingest_queue WHERE synced = 0 ORDER BY id ASC LIMIT ?"
+  )
+    .bind(limit)
+    .all();
+
+  return Response.json({ items: results });
+}
+
+async function handleMarkSynced(request, env) {
+  if (!authenticate(request, env)) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  const ids = body.ids;
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return Response.json({ error: "ids array is required" }, { status: 400 });
+  }
+
+  const statements = ids.map((id) =>
+    env.DB.prepare("UPDATE ingest_queue SET synced = 1 WHERE id = ?").bind(id)
+  );
+
+  await env.DB.batch(statements);
+  return Response.json({ synced: ids.length });
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,14 @@
+name = "crows-nest-ingest"
+main = "src/index.js"
+compatibility_date = "2025-01-01"
+
+# Route: handle /api/* on the existing share domain.
+# All other paths fall through to R2 (media archive).
+routes = [
+  { pattern = "share.bymarkriechers.com/api/*", zone_name = "bymarkriechers.com" }
+]
+
+[[d1_databases]]
+binding = "DB"
+database_name = "crows-nest-ingest"
+database_id = "REPLACE_WITH_D1_DATABASE_ID"

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -11,4 +11,4 @@ routes = [
 [[d1_databases]]
 binding = "DB"
 database_name = "crows-nest-ingest"
-database_id = "REPLACE_WITH_D1_DATABASE_ID"
+database_id = "372349af-f1b9-412c-bb82-9cb7a66c8e4a"


### PR DESCRIPTION
## Summary

Replaces Signal as the single point of failure for link intake with three complementary channels, all converging on the existing `add_link()` entry point. The downstream pipeline (processor → summarizer → archiver) is unchanged.

- **Cloudflare Worker + D1** — `POST /api/ingest` on `share.bymarkriechers.com` with bearer auth. Always-on even when laptop is off. Local poller drains D1 queue into pipeline DB every 5 min.
- **Obsidian vault scanner** — scans notes tagged `pending-clippings` for URLs, ingests them, archives the note to `4 - ARCHIVE/processed-clippings/`. Offline-first fallback.
- **iMessage self-message listener** — polls local iMessage DB for self-sent URLs in direct conversations. Text yourself a link from any Apple device.
- **Enhanced status dashboard** — `status.py --sources` shows breakdown by intake channel. New listeners registered in health checks.

Signal listener continues as a parallel channel when authenticated.

### Verified live
| Channel | Test | Result |
|---------|------|--------|
| Worker `/api/ingest` | curl POST with bearer token | Queued, ID returned |
| Worker auth | POST without token | 401 rejected |
| R2 media serving | Existing `.mp4` share URL | 200 OK, unaffected |
| Ingest poller | Drained test item from D1 → local DB | 1 item, `source_type=ingest-api` |
| Obsidian scanner | 19 TikTok URLs from real vault note | All ingested, note archived |
| iMessage listener | Self-sent Reddit link + images | URL ingested, images ignored |
| `--sources` dashboard | After all tests | Shows breakdown by channel |

### Post-merge setup
- iOS Shortcut creation (documented in plan)
- Install 3 launchd plists (update paths in plists first)
- Follow-up issues: #56 (source_type in frontmatter), #57 (date-based folders)

Closes #44

## Test plan
- [x] 132 tests passing (108 original + 24 new), zero regressions
- [x] Ingest poller: 8 tests (fetch, mark-synced, drain orchestration, duplicates)
- [x] Obsidian scanner: 9 tests (tag detection, URL extraction, ingestion, archiving)
- [x] iMessage listener: 5 tests (message filtering, URL extraction, state persistence)
- [x] Status sources: 2 tests (breakdown display, empty DB)
- [x] Live verification of all channels against real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)