### PR TITLE
feat: intake field in frontmatter + date-based clipping folders

### DIFF
--- a/docs/superpowers/plans/2026-04-07-note-organization.md
+++ b/docs/superpowers/plans/2026-04-07-note-organization.md
@@ -1,0 +1,170 @@
+# Note Organization: Source Type + Date Folders Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `intake` field to Obsidian note frontmatter showing which channel the link came from, and organize clippings into `YYYY/MM/DD` date-based subfolders for discoverability.
+
+**Architecture:** Two changes to `summarizer.py`: (1) `build_frontmatter()` gets a new `intake` param for the source_type, (2) `write_obsidian_note()` gets a `created_at` param and builds date subfolders under `OBSIDIAN_CLIPPINGS`.
+
+**Tech Stack:** Python 3.11+
+
+**GitHub Issues:** #56, #57
+
+---
+
+## File Structure
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `pipeline/summarizer.py` | Add `intake` param to `build_frontmatter()`, add `created_at` param to `write_obsidian_note()` for date subfolder |
+| `tests/pipeline/test_summarizer.py` | Update existing tests, add new tests for intake field and date folders |
+
+---
+
+## Task 1: Add `intake` field to frontmatter
+
+**Files:**
+- Modify: `pipeline/summarizer.py:57-114` (build_frontmatter)
+- Modify: `pipeline/summarizer.py:1126-1133` (caller)
+- Modify: `tests/pipeline/test_summarizer.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/pipeline/test_summarizer.py`:
+
+```python
+def test_build_frontmatter_includes_intake():
+    """Verify intake field appears in frontmatter when provided."""
+    result = build_frontmatter(
+        title="iMessage Link",
+        source="https://example.com/test",
+        content_type="web_page",
+        tags=["test"],
+        intake="imessage",
+    )
+    assert "intake: imessage" in result
+
+
+def test_build_frontmatter_intake_defaults_to_unknown():
+    """Verify intake defaults to 'unknown' when not provided."""
+    result = build_frontmatter(
+        title="Mystery Link",
+        source="https://example.com/test",
+        content_type="web_page",
+        tags=[],
+    )
+    assert "intake: unknown" in result
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/pipeline/test_summarizer.py -v`
+Expected: FAIL — `build_frontmatter() got an unexpected keyword argument 'intake'`
+
+- [ ] **Step 3: Add `intake` param to `build_frontmatter()`**
+
+In `pipeline/summarizer.py`, add `intake: str = "unknown"` parameter to `build_frontmatter()` signature, and add `f"intake: {intake}"` to the frontmatter lines after the `content-type` line.
+
+- [ ] **Step 4: Pass `intake` from the caller**
+
+At line 1126, add `intake=link.get("source_type", "unknown")` to the `build_frontmatter()` call.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/pipeline/test_summarizer.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pipeline/summarizer.py tests/pipeline/test_summarizer.py
+git commit -m "feat: add intake field to Obsidian note frontmatter
+
+Shows which channel the link came from (signal, imessage, obsidian,
+ingest-api, cli). Defaults to 'unknown' for backward compatibility.
+
+Closes #56"
+```
+
+---
+
+## Task 2: Date-based folder organization
+
+**Files:**
+- Modify: `pipeline/summarizer.py:814-839` (write_obsidian_note)
+- Modify: `pipeline/summarizer.py:1152` (caller)
+- Modify: `tests/pipeline/test_summarizer.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/pipeline/test_summarizer.py`:
+
+```python
+def test_write_obsidian_note_date_subfolder(tmp_path):
+    """Notes should be written to YYYY/MM/DD subfolders when created_at is provided."""
+    import summarizer
+    original = summarizer.OBSIDIAN_CLIPPINGS
+    summarizer.OBSIDIAN_CLIPPINGS = str(tmp_path)
+    try:
+        path = summarizer.write_obsidian_note(
+            title="Test Note",
+            frontmatter="---\ntitle: Test\n---",
+            body="Hello world",
+            created_at="2026-04-06T12:00:00",
+        )
+        assert "/2026/04/06/" in path
+        assert os.path.exists(path)
+        assert path.endswith("Test Note.md")
+    finally:
+        summarizer.OBSIDIAN_CLIPPINGS = original
+
+
+def test_write_obsidian_note_no_date_uses_flat(tmp_path):
+    """Without created_at, notes go to the flat clippings directory."""
+    import summarizer
+    original = summarizer.OBSIDIAN_CLIPPINGS
+    summarizer.OBSIDIAN_CLIPPINGS = str(tmp_path)
+    try:
+        path = summarizer.write_obsidian_note(
+            title="Flat Note",
+            frontmatter="---\ntitle: Flat\n---",
+            body="No date",
+        )
+        # Should be directly in tmp_path, no date subfolder
+        assert os.path.dirname(path) == str(tmp_path)
+    finally:
+        summarizer.OBSIDIAN_CLIPPINGS = original
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/pipeline/test_summarizer.py -v`
+Expected: FAIL — `write_obsidian_note() got an unexpected keyword argument 'created_at'`
+
+- [ ] **Step 3: Add `created_at` param to `write_obsidian_note()`**
+
+Add `created_at: str = None` parameter. When provided, parse the date and build `YYYY/MM/DD` subfolder under `OBSIDIAN_CLIPPINGS`.
+
+- [ ] **Step 4: Pass `created_at` from the caller**
+
+At line 1152, add `created_at=link.get("created_at")` to the `write_obsidian_note()` call.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/pipeline/test_summarizer.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pipeline/summarizer.py tests/pipeline/test_summarizer.py
+git commit -m "feat: organize clippings into YYYY/MM/DD date subfolders
+
+Notes now land in INTERNET CLIPPINGS/2026/04/07/ instead of a flat
+directory. Date derived from the link's created_at timestamp.
+Falls back to flat directory when no date is available.
+
+Closes #57"
+```

--- a/pipeline/summarizer.py
+++ b/pipeline/summarizer.py
@@ -61,6 +61,7 @@ def build_frontmatter(
     tags: list,
     sender: str = None,
     metadata: dict = None,
+    intake: str = "unknown",
 ) -> str:
     """Build YAML frontmatter matching Obsidian vault conventions.
 
@@ -85,6 +86,7 @@ def build_frontmatter(
         f"source: {source}",
         f"created: {created}",
         f"content-type: {content_type}",
+        f"intake: {intake}",
     ]
 
     if metadata.get("platform"):
@@ -811,24 +813,37 @@ def _extract_json(text: str) -> dict | None:
 # Note writer
 # ---------------------------------------------------------------------------
 
-def write_obsidian_note(title: str, frontmatter: str, body: str) -> str:
+def write_obsidian_note(title: str, frontmatter: str, body: str,
+                        created_at: str = None) -> str:
     """Write a note to the Obsidian clippings directory.
 
+    When created_at is provided, notes are organized into YYYY/MM/DD
+    subfolders for easier discoverability. Falls back to flat directory.
     Handles filename collisions with (1), (2) suffixes.
     Returns the absolute file path.
     """
-    os.makedirs(OBSIDIAN_CLIPPINGS, exist_ok=True)
+    # Build target directory — date subfolder if created_at is available
+    target_dir = OBSIDIAN_CLIPPINGS
+    if created_at:
+        try:
+            date_str = created_at[:10]  # "2026-04-06T12:00:00" → "2026-04-06"
+            year, month, day = date_str.split("-")
+            target_dir = os.path.join(OBSIDIAN_CLIPPINGS, year, month, day)
+        except (ValueError, IndexError):
+            pass  # malformed date — fall back to flat directory
+
+    os.makedirs(target_dir, exist_ok=True)
 
     safe_title = sanitize_title(title)
     if not safe_title:
         safe_title = "untitled"
 
-    base_path = os.path.join(OBSIDIAN_CLIPPINGS, f"{safe_title}.md")
+    base_path = os.path.join(target_dir, f"{safe_title}.md")
     file_path = base_path
 
     counter = 1
     while os.path.exists(file_path):
-        file_path = os.path.join(OBSIDIAN_CLIPPINGS, f"{safe_title} ({counter}).md")
+        file_path = os.path.join(target_dir, f"{safe_title} ({counter}).md")
         counter += 1
 
     note_content = f"{frontmatter}\n\n{body}\n"
@@ -1130,6 +1145,7 @@ def run(db_path: str) -> None:
                 tags=claude_result.get("tags", []),
                 sender=sender,
                 metadata=metadata,
+                intake=link.get("source_type") or "unknown",
             )
 
             body = generate_note_content(
@@ -1149,7 +1165,10 @@ def run(db_path: str) -> None:
                 extracted_text=extracted_text,
             )
 
-            note_path = write_obsidian_note(title, frontmatter, body)
+            note_path = write_obsidian_note(
+                title, frontmatter, body,
+                created_at=link.get("created_at"),
+            )
             note_title = os.path.splitext(os.path.basename(note_path))[0]
 
             try:

--- a/tests/pipeline/test_summarizer.py
+++ b/tests/pipeline/test_summarizer.py
@@ -134,3 +134,61 @@ def test_generate_note_content_full_transcript_not_truncated():
     assert long_transcript.strip() in result
     assert "truncated" not in result
     assert "<details>" in result
+
+
+def test_build_frontmatter_includes_intake():
+    """Verify intake field appears in frontmatter when provided."""
+    result = build_frontmatter(
+        title="iMessage Link",
+        source="https://example.com/test",
+        content_type="web_page",
+        tags=["test"],
+        intake="imessage",
+    )
+    assert "intake: imessage" in result
+
+
+def test_build_frontmatter_intake_defaults_to_unknown():
+    """Verify intake defaults to 'unknown' when not provided."""
+    result = build_frontmatter(
+        title="Mystery Link",
+        source="https://example.com/test",
+        content_type="web_page",
+        tags=[],
+    )
+    assert "intake: unknown" in result
+
+
+def test_write_obsidian_note_date_subfolder(tmp_path):
+    """Notes should be written to YYYY/MM/DD subfolders when created_at is provided."""
+    import summarizer
+    original = summarizer.OBSIDIAN_CLIPPINGS
+    summarizer.OBSIDIAN_CLIPPINGS = str(tmp_path)
+    try:
+        path = summarizer.write_obsidian_note(
+            title="Test Note",
+            frontmatter="---\ntitle: Test\n---",
+            body="Hello world",
+            created_at="2026-04-06T12:00:00",
+        )
+        assert "/2026/04/06/" in path
+        assert os.path.exists(path)
+        assert path.endswith("Test Note.md")
+    finally:
+        summarizer.OBSIDIAN_CLIPPINGS = original
+
+
+def test_write_obsidian_note_no_date_uses_flat(tmp_path):
+    """Without created_at, notes go to the flat clippings directory."""
+    import summarizer
+    original = summarizer.OBSIDIAN_CLIPPINGS
+    summarizer.OBSIDIAN_CLIPPINGS = str(tmp_path)
+    try:
+        path = summarizer.write_obsidian_note(
+            title="Flat Note",
+            frontmatter="---\ntitle: Flat\n---",
+            body="No date",
+        )
+        assert os.path.dirname(path) == str(tmp_path)
+    finally:
+        summarizer.OBSIDIAN_CLIPPINGS = original


### PR DESCRIPTION
## Summary

Two discoverability improvements for Obsidian clipping notes:

- **`intake` field in frontmatter** — shows which channel the link came from (`signal`, `imessage`, `obsidian`, `ingest-api`, `cli`). Enables filtering by source in Obsidian.
- **Date-based folders** — notes now land in `INTERNET CLIPPINGS/2026/04/07/` instead of a flat directory. Makes it easy to find "what did I save today?" and browse chronologically.

Both changes are backward-compatible: existing notes are unaffected, and the `intake` field defaults to `unknown` when source_type is missing.

Closes #56, closes #57

## Test plan
- [x] 136 tests passing (132 + 4 new), zero regressions
- [x] `intake` field appears when provided, defaults to `unknown`
- [x] Date subfolder created from `created_at` timestamp
- [x] Falls back to flat directory when no date available
- [x] Existing frontmatter tests still pass (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)