### PR TITLE
feat: SSE transport support for MCP server

### DIFF
--- a/launchd/com.crows-nest.mcp.plist
+++ b/launchd/com.crows-nest.mcp.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.crows-nest.mcp</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/mriechers/Developer/second-brain/crows-nest/.venv/bin/python</string>
+        <string>-m</string>
+        <string>mcp_knowledge.server</string>
+        <string>sse</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/mriechers/Developer/second-brain/crows-nest</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PYTHONPATH</key>
+        <string>/Users/mriechers/Developer/second-brain/crows-nest</string>
+        <key>MCP_TRANSPORT</key>
+        <string>sse</string>
+        <key>MCP_SSE_PORT</key>
+        <string>27185</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/mriechers/Developer/second-brain/crows-nest/logs/mcp-server.stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/mriechers/Developer/second-brain/crows-nest/logs/mcp-server.stderr.log</string>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/scripts/install-launchd.sh
+++ b/scripts/install-launchd.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLIST_NAME="com.crows-nest.mcp"
+PLIST_SRC="$(cd "$(dirname "$0")/../launchd" && pwd)/${PLIST_NAME}.plist"
+PLIST_DST="$HOME/Library/LaunchAgents/${PLIST_NAME}.plist"
+LOG_DIR="$(cd "$(dirname "$0")/.." && pwd)/logs"
+
+case "${1:-install}" in
+    install)
+        mkdir -p "$LOG_DIR"
+        mkdir -p "$(dirname "$PLIST_DST")"
+
+        # Unload if already loaded
+        launchctl bootout "gui/$(id -u)/${PLIST_NAME}" 2>/dev/null || true
+
+        cp "$PLIST_SRC" "$PLIST_DST"
+        launchctl bootstrap "gui/$(id -u)" "$PLIST_DST"
+        echo "Installed and started ${PLIST_NAME}"
+        echo "  Logs: ${LOG_DIR}/mcp-server.{stdout,stderr}.log"
+        echo "  Status: launchctl print gui/$(id -u)/${PLIST_NAME}"
+        ;;
+
+    uninstall)
+        launchctl bootout "gui/$(id -u)/${PLIST_NAME}" 2>/dev/null || true
+        rm -f "$PLIST_DST"
+        echo "Uninstalled ${PLIST_NAME}"
+        ;;
+
+    status)
+        launchctl print "gui/$(id -u)/${PLIST_NAME}" 2>&1 | head -20
+        ;;
+
+    restart)
+        launchctl kickstart -k "gui/$(id -u)/${PLIST_NAME}"
+        echo "Restarted ${PLIST_NAME}"
+        ;;
+
+    *)
+        echo "Usage: $0 {install|uninstall|status|restart}"
+        exit 1
+        ;;
+esac

--- a/src/mcp_knowledge/config.py
+++ b/src/mcp_knowledge/config.py
@@ -63,11 +63,22 @@ SEMANTIC_DATA_DIR = os.environ.get(
 EMBEDDING_MODEL = "BAAI/bge-small-en-v1.5"
 
 # ---------------------------------------------------------------------------
-# HTTP API
+# MCP Transport
+# ---------------------------------------------------------------------------
+
+# Transport mode: "stdio" (default, backward-compat) or "sse" (HTTP daemon)
+MCP_TRANSPORT = os.environ.get("MCP_TRANSPORT", "stdio")
+
+# SSE transport settings (only used when MCP_TRANSPORT=sse)
+MCP_SSE_HOST = os.environ.get("MCP_SSE_HOST", "127.0.0.1")
+MCP_SSE_PORT = int(os.environ.get("MCP_SSE_PORT", "27185"))
+
+# ---------------------------------------------------------------------------
+# HTTP API (legacy — separate from MCP transport)
 # ---------------------------------------------------------------------------
 
 ENABLE_HTTP_API = os.environ.get(
     "CROWS_NEST_HTTP_API", "false"
 ).lower() in ("true", "1", "yes")
-HTTP_PORT = int(os.environ.get("CROWS_NEST_HTTP_PORT", "27185"))
+HTTP_PORT = int(os.environ.get("CROWS_NEST_HTTP_PORT", "27186"))
 HTTP_HOST = os.environ.get("CROWS_NEST_HTTP_HOST", "127.0.0.1")

--- a/src/mcp_knowledge/server.py
+++ b/src/mcp_knowledge/server.py
@@ -43,7 +43,11 @@ except ImportError as _rss_exc:
     logger.warning("RSS db unavailable — pipeline import failed: %s", _rss_exc)
     _RSS_AVAILABLE = False
 
-mcp = FastMCP(config.SERVER_NAME)
+mcp = FastMCP(
+    config.SERVER_NAME,
+    host=config.MCP_SSE_HOST,
+    port=config.MCP_SSE_PORT,
+)
 
 _semantic_index = None
 
@@ -360,6 +364,9 @@ def get_knowledge_document(path: str) -> str:
 
 
 def main() -> None:
+    # Transport: CLI arg > config > default (stdio)
+    transport = sys.argv[1] if len(sys.argv) > 1 else config.MCP_TRANSPORT
+
     if config.ENABLE_HTTP_API:
         index = _get_semantic_index()
         if index is None:
@@ -382,7 +389,9 @@ def main() -> None:
                     logger.exception("HTTP API thread failed to start")
             api_thread = threading.Thread(target=_run_api, daemon=True)
             api_thread.start()
-    mcp.run()
+
+    logger.info("Starting MCP server with transport=%s", transport)
+    mcp.run(transport=transport)
 
 
 if __name__ == "__main__":

--- a/tests/test_config_paths.py
+++ b/tests/test_config_paths.py
@@ -7,3 +7,18 @@ def test_clippings_path_points_to_areas():
     assert "2 - AREAS" in OBSIDIAN_CLIPPINGS
     assert "INTERNET CLIPPINGS" in OBSIDIAN_CLIPPINGS
     assert "0 - INBOX" not in OBSIDIAN_CLIPPINGS
+
+
+class TestTransportConfig:
+    def test_default_transport_is_stdio(self):
+        """Default transport should be stdio for backward compat."""
+        from mcp_knowledge import config
+        assert config.MCP_TRANSPORT == "stdio"
+
+    def test_default_sse_port(self):
+        from mcp_knowledge import config
+        assert config.MCP_SSE_PORT == 27185
+
+    def test_default_sse_host(self):
+        from mcp_knowledge import config
+        assert config.MCP_SSE_HOST == "127.0.0.1"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -151,3 +151,42 @@ class TestListTopics:
         counts = {item["category"]: item["document_count"] for item in result}
         assert counts["guides"] == 2
         assert counts["policies"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Transport selection
+# ---------------------------------------------------------------------------
+
+
+class TestTransportSelection:
+    def test_main_accepts_sse_arg(self, monkeypatch):
+        """main() should pass transport arg to mcp.run()."""
+        captured = {}
+        def mock_run(transport="stdio", **kwargs):
+            captured["transport"] = transport
+        monkeypatch.setattr(server_mod.mcp, "run", mock_run)
+        monkeypatch.setattr("sys.argv", ["server", "sse"])
+        server_mod.main()
+        assert captured["transport"] == "sse"
+
+    def test_main_defaults_to_config_transport(self, monkeypatch):
+        """main() should use config.MCP_TRANSPORT when no CLI arg."""
+        captured = {}
+        def mock_run(transport="stdio", **kwargs):
+            captured["transport"] = transport
+        monkeypatch.setattr(server_mod.mcp, "run", mock_run)
+        monkeypatch.setattr("sys.argv", ["server"])
+        monkeypatch.setattr(server_mod.config, "MCP_TRANSPORT", "stdio")
+        server_mod.main()
+        assert captured["transport"] == "stdio"
+
+    def test_main_cli_arg_overrides_config(self, monkeypatch):
+        """CLI arg should override config.MCP_TRANSPORT."""
+        captured = {}
+        def mock_run(transport="stdio", **kwargs):
+            captured["transport"] = transport
+        monkeypatch.setattr(server_mod.mcp, "run", mock_run)
+        monkeypatch.setattr("sys.argv", ["server", "sse"])
+        monkeypatch.setattr(server_mod.config, "MCP_TRANSPORT", "stdio")
+        server_mod.main()
+        assert captured["transport"] == "sse"


### PR DESCRIPTION
## Summary

- Add MCP_TRANSPORT, MCP_SSE_HOST, MCP_SSE_PORT config constants with env var overrides
- Update main() to accept transport as CLI arg (defaults to stdio for backward compat)
- Pass host/port to FastMCP constructor for SSE mode
- Add launchd plist and install/uninstall script for persistent daemon

## Test plan

- [x] 212 tests passing (+6 new transport tests), 4 pre-existing failures (unrelated)
- [x] SSE endpoint verified via curl — returns event stream with session ID
- [x] Backward-compatible — defaults to stdio when no arg given

🤖 Generated with [Claude Code](https://claude.com/claude-code)