### PR TITLE
chore: add CI workflow and post-merge reinstall hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: pip install -e ".[dev,rss]"
+        run: pip install -e ".[all,dev]"
 
       - name: Run tests
         run: pytest tests/ -v --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev,rss]"
+
+      - name: Run tests
+        run: pytest tests/ -v --tb=short

--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# post-merge hook: reinstall package when dependencies or source change
+#
+# Runs after `git pull` merges new commits. Checks whether pyproject.toml
+# or any source files changed — if so, reinstalls the package into the
+# local venv so the running MCP server and pipeline always match HEAD.
+#
+# Install: symlink this into your git hooks directory:
+#   ln -sf ../../config/hooks/post-merge "$(git rev-parse --git-dir)/hooks/post-merge"
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+VENV="$REPO_ROOT/.venv"
+
+# Only act if a venv exists
+if [[ ! -d "$VENV" ]]; then
+    exit 0
+fi
+
+# Check if pyproject.toml or source files changed in the merge
+CHANGED_FILES=$(git diff-tree -r --name-only ORIG_HEAD HEAD 2>/dev/null || true)
+
+if echo "$CHANGED_FILES" | grep -qE '(pyproject\.toml|src/|pipeline/)'; then
+    echo "🔄 post-merge: source or dependencies changed, reinstalling..."
+    "$VENV/bin/pip" install -e "$REPO_ROOT" --quiet 2>/dev/null
+    echo "✅ post-merge: reinstall complete"
+fi


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI that runs `pytest` on every PR and push to main
- Add post-merge git hook that auto-reinstalls the package when source or dependencies change after `git pull`
- Hook is stored in-repo at `config/hooks/post-merge` and symlinked into the git hooks dir

## Why
Worktree-based development has led to the local install drifting from main — CI ensures main stays clean, and the post-merge hook ensures the local venv always matches HEAD.

## Test plan
- [x] CI workflow syntax validated
- [x] Hook is executable and symlinked
- [ ] Watch CI run on this PR to confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)