### PR TITLE
chore: add Nice/LowPriorityIO to CPU-heavy launchd jobs

### DIFF
--- a/config/launchd/com.crows-nest.archiver.plist
+++ b/config/launchd/com.crows-nest.archiver.plist
@@ -42,5 +42,14 @@
 
     <key>ProcessType</key>
     <string>Background</string>
+
+    <key>Nice</key>
+    <integer>10</integer>
+
+    <key>LowPriorityIO</key>
+    <true/>
+
+    <key>LowPriorityBackgroundIO</key>
+    <true/>
 </dict>
 </plist>

--- a/config/launchd/com.crows-nest.processor.plist
+++ b/config/launchd/com.crows-nest.processor.plist
@@ -37,5 +37,14 @@
 
     <key>ProcessType</key>
     <string>Background</string>
+
+    <key>Nice</key>
+    <integer>10</integer>
+
+    <key>LowPriorityIO</key>
+    <true/>
+
+    <key>LowPriorityBackgroundIO</key>
+    <true/>
 </dict>
 </plist>

--- a/config/launchd/com.crows-nest.summarizer.plist
+++ b/config/launchd/com.crows-nest.summarizer.plist
@@ -33,9 +33,18 @@
     </dict>
 
     <key>RunAtLoad</key>
-    <true/>
+    <false/>
 
     <key>ProcessType</key>
     <string>Background</string>
+
+    <key>Nice</key>
+    <integer>10</integer>
+
+    <key>LowPriorityIO</key>
+    <true/>
+
+    <key>LowPriorityBackgroundIO</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- Add `Nice: 10`, `LowPriorityIO`, and `LowPriorityBackgroundIO` to processor, summarizer, and archiver launchd plists
- Disable `RunAtLoad` for summarizer to stagger startup and avoid all jobs firing simultaneously at login
- Linux systemd units unchanged — homelab machines keep full priority

Ref #66

## Test plan

- [x] Plists validated and loaded successfully via `launchctl bootstrap`
- [ ] Confirm reduced hitching during pipeline processing on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)