### PR TITLE
feat: add generalized job queue and node heartbeat to D1 Worker

### DIFF
--- a/worker/schema.sql
+++ b/worker/schema.sql
@@ -12,3 +12,30 @@ CREATE TABLE IF NOT EXISTS ingest_queue (
 
 CREATE INDEX IF NOT EXISTS idx_ingest_queue_synced
     ON ingest_queue(synced);
+
+-- Generalized job queue for cross-submodule coordination.
+-- Payloads are POINTERS ONLY — IDs, batch refs, triggers. NEVER content.
+CREATE TABLE IF NOT EXISTS jobs (
+    id         TEXT    PRIMARY KEY,
+    type       TEXT    NOT NULL,
+    payload    TEXT    NOT NULL DEFAULT '{}',
+    status     TEXT    NOT NULL DEFAULT 'pending',
+    priority   INTEGER NOT NULL DEFAULT 0,
+    claimed_by TEXT,
+    claimed_at TEXT,
+    completed_at TEXT,
+    error      TEXT,
+    created_at TEXT    NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_jobs_status ON jobs(status);
+CREATE INDEX IF NOT EXISTS idx_jobs_type   ON jobs(type);
+
+-- Node heartbeats: which machines are alive and what they can do.
+CREATE TABLE IF NOT EXISTS nodes (
+    node_id       TEXT PRIMARY KEY,
+    hostname      TEXT,
+    capabilities  TEXT NOT NULL DEFAULT '[]',
+    last_heartbeat TEXT NOT NULL,
+    current_job   TEXT
+);

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -22,6 +22,26 @@ export default {
       return handleMarkSynced(request, env);
     }
 
+    if (url.pathname === "/api/jobs" && request.method === "POST") {
+      return handleJobCreate(request, env);
+    }
+
+    if (url.pathname === "/api/jobs/claim" && request.method === "POST") {
+      return handleJobClaim(request, env);
+    }
+
+    if (url.pathname === "/api/jobs/complete" && request.method === "POST") {
+      return handleJobComplete(request, env);
+    }
+
+    if (url.pathname === "/api/jobs/pending" && request.method === "GET") {
+      return handleJobsPending(request, env);
+    }
+
+    if (url.pathname === "/api/nodes/heartbeat" && request.method === "POST") {
+      return handleHeartbeat(request, env);
+    }
+
     // Everything else: not handled by this Worker (falls through to R2)
     return fetch(request);
   },
@@ -122,4 +142,168 @@ async function handleMarkSynced(request, env) {
 
   await env.DB.batch(statements);
   return Response.json({ synced: ids.length });
+}
+
+async function handleJobCreate(request, env) {
+  if (!authenticate(request, env)) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  const type = (body.type || "").trim();
+  if (!type) {
+    return Response.json({ error: "type is required" }, { status: 400 });
+  }
+
+  const id = body.id || `${type}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const payload = JSON.stringify(body.payload || {});
+  const priority = body.priority || 0;
+  const now = new Date().toISOString();
+
+  try {
+    await env.DB.prepare(
+      "INSERT INTO jobs (id, type, payload, status, priority, created_at) VALUES (?, ?, ?, 'pending', ?, ?)"
+    )
+      .bind(id, type, payload, priority, now)
+      .run();
+
+    return Response.json({ id, status: "pending", type });
+  } catch (err) {
+    return Response.json(
+      { error: "job insert failed", detail: err.message },
+      { status: 500 }
+    );
+  }
+}
+
+async function handleJobsPending(request, env) {
+  if (!authenticate(request, env)) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const params = new URL(request.url).searchParams;
+  const type = params.get("type");
+  const limit = Math.min(parseInt(params.get("limit") || "20", 10), 100);
+
+  let sql = "SELECT * FROM jobs WHERE status = 'pending'";
+  const binds = [];
+
+  if (type) {
+    sql += " AND type = ?";
+    binds.push(type);
+  }
+
+  sql += " ORDER BY priority DESC, created_at ASC LIMIT ?";
+  binds.push(limit);
+
+  const stmt = env.DB.prepare(sql);
+  const { results } = await stmt.bind(...binds).all();
+
+  return Response.json({ jobs: results });
+}
+
+async function handleJobClaim(request, env) {
+  if (!authenticate(request, env)) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  const jobId = (body.job_id || "").trim();
+  const nodeId = (body.node_id || "").trim();
+  if (!jobId || !nodeId) {
+    return Response.json({ error: "job_id and node_id are required" }, { status: 400 });
+  }
+
+  const now = new Date().toISOString();
+
+  const result = await env.DB.prepare(
+    "UPDATE jobs SET status = 'claimed', claimed_by = ?, claimed_at = ? WHERE id = ? AND status = 'pending'"
+  )
+    .bind(nodeId, now, jobId)
+    .run();
+
+  if (result.meta.changes === 0) {
+    return Response.json({ error: "job not available" }, { status: 409 });
+  }
+
+  return Response.json({ job_id: jobId, claimed_by: nodeId, status: "claimed" });
+}
+
+async function handleJobComplete(request, env) {
+  if (!authenticate(request, env)) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  const jobId = (body.job_id || "").trim();
+  const status = body.status === "failed" ? "failed" : "done";
+  const error = body.error || null;
+  const now = new Date().toISOString();
+
+  if (!jobId) {
+    return Response.json({ error: "job_id is required" }, { status: 400 });
+  }
+
+  await env.DB.prepare(
+    "UPDATE jobs SET status = ?, completed_at = ?, error = ? WHERE id = ? AND status = 'claimed'"
+  )
+    .bind(status, now, error, jobId)
+    .run();
+
+  return Response.json({ job_id: jobId, status });
+}
+
+async function handleHeartbeat(request, env) {
+  if (!authenticate(request, env)) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON" }, { status: 400 });
+  }
+
+  const nodeId = (body.node_id || "").trim();
+  if (!nodeId) {
+    return Response.json({ error: "node_id is required" }, { status: 400 });
+  }
+
+  const hostname = body.hostname || "";
+  const capabilities = JSON.stringify(body.capabilities || []);
+  const currentJob = body.current_job || null;
+  const now = new Date().toISOString();
+
+  await env.DB.prepare(
+    `INSERT INTO nodes (node_id, hostname, capabilities, last_heartbeat, current_job)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(node_id) DO UPDATE SET
+       hostname = excluded.hostname,
+       capabilities = excluded.capabilities,
+       last_heartbeat = excluded.last_heartbeat,
+       current_job = excluded.current_job`
+  )
+    .bind(nodeId, hostname, capabilities, now, currentJob)
+    .run();
+
+  return Response.json({ node_id: nodeId, last_heartbeat: now });
 }

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -93,8 +93,9 @@ async function handleIngest(request, env) {
       url: linkUrl,
     });
   } catch (err) {
+    console.error("queue insert failed:", err.message);
     return Response.json(
-      { error: "queue insert failed", detail: err.message },
+      { error: "queue insert failed" },
       { status: 500 }
     );
   }
@@ -161,9 +162,12 @@ async function handleJobCreate(request, env) {
     return Response.json({ error: "type is required" }, { status: 400 });
   }
 
+  if (body.id && !/^[a-zA-Z0-9_-]{1,128}$/.test(body.id)) {
+    return Response.json({ error: "invalid id format" }, { status: 400 });
+  }
   const id = body.id || `${type}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const payload = JSON.stringify(body.payload || {});
-  const priority = body.priority || 0;
+  const priority = Number.isInteger(body.priority) ? body.priority : 0;
   const now = new Date().toISOString();
 
   try {
@@ -175,8 +179,9 @@ async function handleJobCreate(request, env) {
 
     return Response.json({ id, status: "pending", type });
   } catch (err) {
+    console.error("job insert failed:", err.message);
     return Response.json(
-      { error: "job insert failed", detail: err.message },
+      { error: "job insert failed" },
       { status: 500 }
     );
   }
@@ -202,10 +207,14 @@ async function handleJobsPending(request, env) {
   sql += " ORDER BY priority DESC, created_at ASC LIMIT ?";
   binds.push(limit);
 
-  const stmt = env.DB.prepare(sql);
-  const { results } = await stmt.bind(...binds).all();
-
-  return Response.json({ jobs: results });
+  try {
+    const stmt = env.DB.prepare(sql);
+    const { results } = await stmt.bind(...binds).all();
+    return Response.json({ jobs: results });
+  } catch (err) {
+    console.error("jobs pending query failed:", err.message);
+    return Response.json({ error: "query failed" }, { status: 500 });
+  }
 }
 
 async function handleJobClaim(request, env) {
@@ -228,17 +237,22 @@ async function handleJobClaim(request, env) {
 
   const now = new Date().toISOString();
 
-  const result = await env.DB.prepare(
-    "UPDATE jobs SET status = 'claimed', claimed_by = ?, claimed_at = ? WHERE id = ? AND status = 'pending'"
-  )
-    .bind(nodeId, now, jobId)
-    .run();
+  try {
+    const result = await env.DB.prepare(
+      "UPDATE jobs SET status = 'claimed', claimed_by = ?, claimed_at = ? WHERE id = ? AND status = 'pending'"
+    )
+      .bind(nodeId, now, jobId)
+      .run();
 
-  if (result.meta.changes === 0) {
-    return Response.json({ error: "job not available" }, { status: 409 });
+    if (result.meta.changes === 0) {
+      return Response.json({ error: "job not available" }, { status: 409 });
+    }
+
+    return Response.json({ job_id: jobId, claimed_by: nodeId, status: "claimed" });
+  } catch (err) {
+    console.error("job claim failed:", err.message);
+    return Response.json({ error: "claim failed" }, { status: 500 });
   }
-
-  return Response.json({ job_id: jobId, claimed_by: nodeId, status: "claimed" });
 }
 
 async function handleJobComplete(request, env) {
@@ -262,13 +276,22 @@ async function handleJobComplete(request, env) {
     return Response.json({ error: "job_id is required" }, { status: 400 });
   }
 
-  await env.DB.prepare(
-    "UPDATE jobs SET status = ?, completed_at = ?, error = ? WHERE id = ? AND status = 'claimed'"
-  )
-    .bind(status, now, error, jobId)
-    .run();
+  try {
+    const result = await env.DB.prepare(
+      "UPDATE jobs SET status = ?, completed_at = ?, error = ? WHERE id = ? AND status = 'claimed'"
+    )
+      .bind(status, now, error, jobId)
+      .run();
 
-  return Response.json({ job_id: jobId, status });
+    if (result.meta.changes === 0) {
+      return Response.json({ error: "job not found or not in claimed state" }, { status: 409 });
+    }
+
+    return Response.json({ job_id: jobId, status });
+  } catch (err) {
+    console.error("job complete failed:", err.message);
+    return Response.json({ error: "complete failed" }, { status: 500 });
+  }
 }
 
 async function handleHeartbeat(request, env) {
@@ -293,17 +316,22 @@ async function handleHeartbeat(request, env) {
   const currentJob = body.current_job || null;
   const now = new Date().toISOString();
 
-  await env.DB.prepare(
-    `INSERT INTO nodes (node_id, hostname, capabilities, last_heartbeat, current_job)
-     VALUES (?, ?, ?, ?, ?)
-     ON CONFLICT(node_id) DO UPDATE SET
-       hostname = excluded.hostname,
-       capabilities = excluded.capabilities,
-       last_heartbeat = excluded.last_heartbeat,
-       current_job = excluded.current_job`
-  )
-    .bind(nodeId, hostname, capabilities, now, currentJob)
-    .run();
+  try {
+    await env.DB.prepare(
+      `INSERT INTO nodes (node_id, hostname, capabilities, last_heartbeat, current_job)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(node_id) DO UPDATE SET
+         hostname = excluded.hostname,
+         capabilities = excluded.capabilities,
+         last_heartbeat = excluded.last_heartbeat,
+         current_job = excluded.current_job`
+    )
+      .bind(nodeId, hostname, capabilities, now, currentJob)
+      .run();
 
-  return Response.json({ node_id: nodeId, last_heartbeat: now });
+    return Response.json({ node_id: nodeId, last_heartbeat: now });
+  } catch (err) {
+    console.error("heartbeat failed:", err.message);
+    return Response.json({ error: "heartbeat failed" }, { status: 500 });
+  }
 }

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -165,7 +165,7 @@ async function handleJobCreate(request, env) {
   if (body.id && !/^[a-zA-Z0-9_-]{1,128}$/.test(body.id)) {
     return Response.json({ error: "invalid id format" }, { status: 400 });
   }
-  const id = body.id || `${type}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const id = body.id || crypto.randomUUID();
   const payload = JSON.stringify(body.payload || {});
   const priority = Number.isInteger(body.priority) ? body.priority : 0;
   const now = new Date().toISOString();


### PR DESCRIPTION
## Summary
- Add `jobs` and `nodes` tables to D1 schema for cross-submodule job coordination
- Add 5 new Worker endpoints: POST /api/jobs, GET /api/jobs/pending, POST /api/jobs/claim, POST /api/jobs/complete, POST /api/nodes/heartbeat
- All endpoints reuse existing Bearer token authentication
- Schema and Worker already deployed to production and verified

## Context
Part of Resilient Infrastructure Phase 1. The job queue enables multi-node coordination — any machine can post jobs, and any runner can claim and process them. D1 only stores job pointers (IDs, types, timestamps), never content.

## Test plan
- [x] Schema deployed to D1, tables verified (`ingest_queue`, `jobs`, `nodes`)
- [x] Worker deployed, all 5 endpoints tested live via curl
- [x] Existing `/api/health`, `/api/ingest`, `/api/pending` endpoints unaffected
- [x] Atomic job claiming verified (409 on double-claim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)