### PR TITLE
feat: harden Signal listener and add HTTP /add-link fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Two systems in one repo: an **MCP knowledge server** and a **Signal-to-Obsidian 
 - `pipeline/db.py` — SQLite status machine (pending → downloading → transcribed → summarized → archived)
 - `pipeline/status.py` — dashboard (`python status.py`) and health check (`python status.py --health`)
 - `pipeline/add_link.py` — CLI to manually queue URLs
+- `pipeline/signal_doctor.py` — diagnostic CLI for signal-cli auth/setup issues (`python signal_doctor.py`)
 - `pipeline/keychain_secrets.py` — macOS Keychain with env var fallback for API keys
 - `pipeline/fix_obsidian_names.py` — fixes Obsidian filenames with banned characters and updates weekly log wikilinks to match (dry run by default, pass `--apply` to write changes)
 
@@ -38,6 +39,35 @@ cd ~/Developer/second-brain/crows-nest
 
 - **macOS**: launchd plists in `config/launchd/` (installed to `~/Library/LaunchAgents/`)
 - **Linux**: systemd timer/service units in `config/systemd/` (install to `/etc/systemd/system/`)
+
+### Signal listener health & recovery
+
+The listener writes a structured health file at `logs/signal-health.json`
+after every poll. `pipeline/status.py --health` surfaces three states:
+
+- **ok** — last poll reached signal-cli successfully
+- **error** — single transient failure (timeout, subprocess error, ...)
+- **degraded** — 3+ consecutive failures; needs user intervention
+
+The health file also tracks `last_success_at` and `consecutive_failures`
+so `status.py --health` can report "last healthy Nh Mm ago" even while
+the listener is in a failure state.
+
+When Signal ingestion stops working:
+
+1. **Diagnose**: `python pipeline/signal_doctor.py`
+   Runs four checks — SIGNAL_USER configured, signal-cli binary on PATH,
+   signal-cli data directory exists, and a live `receive --timeout 1` —
+   and prints exact recovery commands for each failing check.
+2. **Re-link** (most common fix): when signal-cli reports "not registered",
+   your linked device has expired. Re-link with:
+   ```bash
+   signal-cli -a "+16085551234" link -n "crows-nest"
+   ```
+   then scan the QR code from the Signal mobile app under
+   *Settings → Linked Devices → Link New Device*.
+3. **Fallback capture** while Signal is broken: use the HTTP
+   `/add-link` endpoint (see below) or `python pipeline/add_link.py URL`.
 
 ### Platform portability
 
@@ -110,8 +140,59 @@ Optional localhost HTTP API. Enable via `CROWS_NEST_HTTP_API=true` env var.
 | `/status` | GET | Index health dashboard |
 | `/reindex` | POST | Trigger media archive reindex |
 | `/health` | GET | Liveness check |
+| `/add-link` | POST | Queue a URL for the pipeline (token-authed) |
 
 Default port: 27185. Override: `CROWS_NEST_HTTP_PORT`.
+
+#### /add-link — Signal-independent URL ingestion
+
+`POST /add-link` queues a URL into the same pending pipeline as the Signal
+listener. It is the foundation for iOS/macOS Shortcuts, bookmarklets,
+browser extensions, and any other tool that can make an HTTP call — useful
+whenever the Signal listener is down for auth reasons.
+
+**Enable it** by setting a shared-secret token (required):
+
+```bash
+export CROWS_NEST_HTTP_API=true
+export CROWS_NEST_API_TOKEN="some-long-random-string"
+```
+
+Without `CROWS_NEST_API_TOKEN` the endpoint returns 503. With it, the
+endpoint requires that exact token in the `X-Crows-Nest-Token` header.
+
+**Request body** (JSON):
+
+```json
+{
+  "url": "https://example.com/article",
+  "context": "optional note about why this was saved",
+  "source_type": "http"
+}
+```
+
+`source_type` is optional and defaults to `"http"` — override it to tag
+where the request came from (e.g. `"shortcut"`, `"bookmarklet"`).
+
+**Responses:**
+- `201 {id, status:"queued", content_type, source_type}` — queued successfully
+- `400` — missing or non-string `url`, or invalid JSON body
+- `401` — missing or wrong token
+- `409` — URL already queued (same deduplication as Signal listener)
+- `503` — endpoint disabled (token not set)
+
+**Example** — queue a URL from the command line:
+
+```bash
+curl -X POST http://127.0.0.1:27185/add-link \
+  -H "X-Crows-Nest-Token: $CROWS_NEST_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"url":"https://example.com","context":"manual curl"}'
+```
+
+For remote access (pipeline on Proxmox), front it with Tailscale and
+point the client at the Tailscale IP; the endpoint binds to
+`CROWS_NEST_HTTP_HOST` (default `127.0.0.1`).
 
 ## Development
 

--- a/pipeline/signal_doctor.py
+++ b/pipeline/signal_doctor.py
@@ -1,0 +1,248 @@
+"""Diagnostic CLI for the Signal listener's signal-cli integration.
+
+Runs through the most common failure modes for the Crow's Nest Signal
+listener and prints a verdict for each, along with specific recovery
+steps. Intended to be run by hand when the pipeline stops ingesting
+Signal messages, but can also be invoked by ``pipeline/status.py
+--health`` as an escalation step.
+
+Exit code:
+    0 — every check passed (signal-cli is ready to receive messages)
+    1 — one or more checks failed
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+# Allow running directly from any working directory.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from config import SIGNAL_HEALTH_FILE  # noqa: E402
+from keychain_secrets import get_secret  # noqa: E402
+
+
+SIGNAL_CLI = "signal-cli"
+SIGNAL_DATA_DIR = os.path.expanduser("~/.local/share/signal-cli")
+
+
+class CheckResult:
+    """Result of a single diagnostic check."""
+
+    __slots__ = ("name", "ok", "detail", "recovery")
+
+    def __init__(self, name: str, ok: bool, detail: str, recovery: str = ""):
+        self.name = name
+        self.ok = ok
+        self.detail = detail
+        self.recovery = recovery
+
+
+def check_signal_user() -> CheckResult:
+    """Confirm the SIGNAL_USER phone number is configured."""
+    phone = get_secret("SIGNAL_USER") or ""
+    if not phone:
+        return CheckResult(
+            "SIGNAL_USER configured",
+            ok=False,
+            detail="not set in Keychain or environment",
+            recovery=(
+                "Set your Signal phone number (E.164 format, e.g. +16085551234):\n"
+                "  macOS: security add-generic-password -a \"$USER\" "
+                "-s developer.workspace.SIGNAL_USER -w +16085551234 -U\n"
+                "  Linux: export SIGNAL_USER=+16085551234"
+            ),
+        )
+    return CheckResult(
+        "SIGNAL_USER configured",
+        ok=True,
+        detail=phone,
+    )
+
+
+def check_signal_cli_binary() -> CheckResult:
+    """Confirm the signal-cli binary is on PATH."""
+    path = shutil.which(SIGNAL_CLI)
+    if not path:
+        return CheckResult(
+            "signal-cli binary",
+            ok=False,
+            detail="not found on PATH",
+            recovery=(
+                "Install signal-cli:\n"
+                "  macOS: brew install signal-cli\n"
+                "  Linux: see https://github.com/AsamK/signal-cli/wiki/Installation"
+            ),
+        )
+    return CheckResult("signal-cli binary", ok=True, detail=path)
+
+
+def check_data_directory() -> CheckResult:
+    """Confirm signal-cli's data directory exists."""
+    if not os.path.isdir(SIGNAL_DATA_DIR):
+        return CheckResult(
+            "signal-cli data directory",
+            ok=False,
+            detail=f"missing: {SIGNAL_DATA_DIR}",
+            recovery=(
+                "signal-cli has never been registered on this machine. "
+                "Link it as a secondary device to your phone:\n"
+                "  signal-cli link -n \"crows-nest\"\n"
+                "then scan the QR code it prints from the Signal mobile app."
+            ),
+        )
+    return CheckResult(
+        "signal-cli data directory",
+        ok=True,
+        detail=SIGNAL_DATA_DIR,
+    )
+
+
+def check_receive(phone: str) -> CheckResult:
+    """Run a short `signal-cli receive` to confirm the account is live."""
+    cmd = [SIGNAL_CLI, "-u", phone, "-o", "json", "receive", "--timeout", "1"]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=10,
+        )
+    except FileNotFoundError:
+        return CheckResult(
+            "signal-cli receive",
+            ok=False,
+            detail="signal-cli binary vanished between checks",
+            recovery="Re-install signal-cli and retry.",
+        )
+    except subprocess.TimeoutExpired:
+        return CheckResult(
+            "signal-cli receive",
+            ok=False,
+            detail="receive hung for >10s (timed out)",
+            recovery=(
+                "Network/server hang. Retry later; if persistent, "
+                "check your internet connection and Signal's status page."
+            ),
+        )
+
+    stderr = (result.stderr or "").strip()
+    if result.returncode == 0:
+        return CheckResult(
+            "signal-cli receive",
+            ok=True,
+            detail="account reached Signal servers successfully",
+        )
+
+    if "not registered" in stderr.lower():
+        return CheckResult(
+            "signal-cli receive",
+            ok=False,
+            detail=f"account {phone} is not registered",
+            recovery=(
+                "Your linked device has been invalidated. Re-link it:\n"
+                f"  signal-cli -a \"{phone}\" link -n \"crows-nest\"\n"
+                "then scan the QR code from the Signal mobile app "
+                "(Settings → Linked Devices → Link New Device)."
+            ),
+        )
+
+    return CheckResult(
+        "signal-cli receive",
+        ok=False,
+        detail=f"exit {result.returncode}: {stderr[:200]}",
+        recovery="Inspect the stderr above and consult signal-cli docs.",
+    )
+
+
+def read_health() -> dict:
+    """Return the current contents of the signal-health.json file."""
+    if not os.path.exists(SIGNAL_HEALTH_FILE):
+        return {}
+    try:
+        with open(SIGNAL_HEALTH_FILE, "r", encoding="utf-8") as f:
+            return json.load(f) or {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def summarize_health(health: dict) -> str:
+    """Produce a human-readable summary of the listener's current health."""
+    if not health:
+        return "no health file found (listener has not run yet)"
+
+    status = health.get("status", "unknown")
+    lines = [f"status: {status}"]
+    if health.get("error"):
+        lines.append(f"error:  {health['error']}")
+    if health.get("message"):
+        lines.append(f"detail: {health['message']}")
+    if health.get("last_success_at"):
+        try:
+            last = datetime.fromisoformat(health["last_success_at"])
+            age = (datetime.now(timezone.utc) - last).total_seconds() / 60
+            lines.append(f"last success: {health['last_success_at']} ({int(age)}m ago)")
+        except ValueError:
+            lines.append(f"last success: {health['last_success_at']}")
+    streak = health.get("consecutive_failures")
+    if streak:
+        lines.append(f"consecutive failures: {streak}")
+    return "\n  ".join(lines)
+
+
+def run_checks() -> list[CheckResult]:
+    """Run all diagnostic checks in order and return results."""
+    results: list[CheckResult] = []
+
+    user_result = check_signal_user()
+    results.append(user_result)
+
+    binary_result = check_signal_cli_binary()
+    results.append(binary_result)
+
+    results.append(check_data_directory())
+
+    if user_result.ok and binary_result.ok:
+        results.append(check_receive(user_result.detail))
+
+    return results
+
+
+def main() -> None:
+    print()
+    print("CROW'S NEST — Signal Doctor")
+    print("=" * 40)
+    print()
+
+    health = read_health()
+    print("Listener health file:")
+    print("  " + summarize_health(health))
+    print()
+
+    results = run_checks()
+    all_ok = True
+
+    for res in results:
+        mark = "OK  " if res.ok else "FAIL"
+        print(f"  [{mark}] {res.name}: {res.detail}")
+        if not res.ok:
+            all_ok = False
+            if res.recovery:
+                for line in res.recovery.splitlines():
+                    print(f"         {line}")
+            print()
+
+    print()
+    if all_ok:
+        print("  DIAGNOSIS: signal-cli looks healthy")
+    else:
+        print("  DIAGNOSIS: signal-cli needs attention — see failures above")
+    print()
+
+    sys.exit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/signal_listener.py
+++ b/pipeline/signal_listener.py
@@ -202,18 +202,33 @@ def _batch_image_messages(messages: list[dict]) -> tuple[list[dict], list[dict]]
     return image_batches, non_image_messages
 
 
+# Last-failure details from receive_messages(), consumed by run() so it
+# can distinguish auth/registration errors from transient subprocess errors
+# when writing to the health file. Keys: ``error`` (short code) and
+# ``message`` (human-readable). Reset to {} at the start of each call.
+_LAST_RECEIVE_ERROR: dict = {}
+
+
 def receive_messages() -> list[dict] | None:
     """Invoke signal-cli in JSON mode and return parsed messages.
 
     Calls `signal-cli -u {SIGNAL_USER} receive --timeout {RECEIVE_TIMEOUT} --json`.
     The command returns all buffered messages in a single invocation.
 
+    On failure, ``_LAST_RECEIVE_ERROR`` is populated with an ``error`` code
+    and ``message`` so callers can forward structured detail to the health
+    file without re-interpreting stderr.
+
     Returns:
         List of dicts with keys "sender_id", "sender_name", "message",
         "timestamp", "group_name", "attachments".
-        Returns an empty list on any subprocess error.
-        Returns None on fatal errors (e.g. account not registered).
+        Returns None on any failure (auth error, subprocess error, timeout
+        with no output). Partial-timeout salvage is still treated as
+        success and returns the parsed partial list.
     """
+    global _LAST_RECEIVE_ERROR  # noqa: PLW0603 — module-level error state
+    _LAST_RECEIVE_ERROR = {}
+
     cmd = [
         SIGNAL_CLI,
         "-u", SIGNAL_USER,
@@ -237,8 +252,20 @@ def receive_messages() -> list[dict] | None:
                     "Re-register with: signal-cli -u %s register && signal-cli -u %s verify CODE",
                     SIGNAL_USER, SIGNAL_USER,
                 )
+                _LAST_RECEIVE_ERROR = {
+                    "error": "not_registered",
+                    "message": (
+                        f"signal-cli account {SIGNAL_USER} is not registered. "
+                        f"Run: signal-cli -u {SIGNAL_USER} register && "
+                        f"signal-cli -u {SIGNAL_USER} verify CODE"
+                    ),
+                }
                 return None
             logger.error("signal-cli exited %d: %s", result.returncode, stderr)
+            _LAST_RECEIVE_ERROR = {
+                "error": "signal_cli_error",
+                "message": f"signal-cli exited {result.returncode}: {stderr[:200]}",
+            }
             return None
         return _parse_json_output(result.stdout)
     except subprocess.TimeoutExpired as exc:
@@ -251,10 +278,18 @@ def receive_messages() -> list[dict] | None:
             logger.warning("signal-cli timed out but captured partial output (%d bytes) — parsing", len(partial))
             return _parse_json_output(partial)
         logger.error("signal-cli timed out with no output")
-        return []
+        _LAST_RECEIVE_ERROR = {
+            "error": "timeout",
+            "message": f"signal-cli receive timed out after {RECEIVE_TIMEOUT + 5}s with no output",
+        }
+        return None
     except Exception as exc:
         logger.error("Failed to receive Signal messages: %s", exc)
-        return []
+        _LAST_RECEIVE_ERROR = {
+            "error": "subprocess_error",
+            "message": f"signal-cli invocation failed: {exc}",
+        }
+        return None
 
 
 def send_confirmation(recipient: str, message: str) -> None:
@@ -290,20 +325,96 @@ def _log_message(sender: str, body: str, group: str = "") -> None:
         logger.warning("Could not write to message log: %s", exc)
 
 
-def _write_health(status: str, error: str = "", message: str = "") -> None:
-    """Write a machine-readable health status file for the signal listener."""
+def _read_health() -> dict:
+    """Read the current health file, returning {} if missing or unreadable."""
+    if not os.path.exists(SIGNAL_HEALTH_FILE):
+        return {}
+    try:
+        with open(SIGNAL_HEALTH_FILE, "r", encoding="utf-8") as f:
+            return json.load(f) or {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _write_health(
+    status: str,
+    error: str = "",
+    message: str = "",
+    last_success_at: str | None = None,
+    consecutive_failures: int | None = None,
+) -> None:
+    """Write a machine-readable health status file for the signal listener.
+
+    Preserves prior ``last_success_at`` across error writes so status.py can
+    show how long it has been since the listener successfully reached
+    signal-cli, regardless of how many poll cycles have failed since then.
+
+    Args:
+        status: ``ok``, ``error``, or ``degraded``.
+        error: Short machine-readable error code.
+        message: Human-readable description.
+        last_success_at: ISO timestamp to record. If None, preserves any
+            existing value from the previous health file.
+        consecutive_failures: Failure streak count. Passed through as-is;
+            callers manage the increment/reset logic.
+    """
     ts = datetime.now(timezone.utc).isoformat()
-    payload = {"status": status, "timestamp": ts}
+    prior = _read_health()
+    payload: dict = {"status": status, "timestamp": ts}
     if error:
         payload["error"] = error
     if message:
         payload["message"] = message
+
+    # Preserve last_success_at across error writes unless overridden.
+    if last_success_at is not None:
+        payload["last_success_at"] = last_success_at
+    elif prior.get("last_success_at"):
+        payload["last_success_at"] = prior["last_success_at"]
+
+    if consecutive_failures is not None:
+        payload["consecutive_failures"] = consecutive_failures
+
     try:
         os.makedirs(os.path.dirname(SIGNAL_HEALTH_FILE), exist_ok=True)
         with open(SIGNAL_HEALTH_FILE, "w", encoding="utf-8") as f:
             json.dump(payload, f)
     except OSError as exc:
         logger.warning("Could not write health file: %s", exc)
+
+
+# Threshold after which the listener reports "degraded" instead of "error".
+# Once degraded, status.py escalates the warning even if the next poll
+# happens to be an explicit failure vs a silent empty-return.
+DEGRADED_FAILURE_THRESHOLD = 3
+
+
+def _record_success() -> None:
+    """Mark the listener as healthy and reset the failure streak."""
+    now = datetime.now(timezone.utc).isoformat()
+    _write_health(
+        status="ok",
+        last_success_at=now,
+        consecutive_failures=0,
+    )
+
+
+def _record_failure(error: str, message: str) -> None:
+    """Record a failed receive, incrementing the consecutive-failure counter.
+
+    After ``DEGRADED_FAILURE_THRESHOLD`` consecutive failures the listener
+    status transitions from ``error`` to ``degraded`` so monitoring can
+    surface it as a persistent problem rather than a transient blip.
+    """
+    prior = _read_health()
+    streak = int(prior.get("consecutive_failures", 0) or 0) + 1
+    status = "degraded" if streak >= DEGRADED_FAILURE_THRESHOLD else "error"
+    _write_health(
+        status=status,
+        error=error,
+        message=message,
+        consecutive_failures=streak,
+    )
 
 
 def run(db_path: str) -> None:
@@ -321,17 +432,22 @@ def run(db_path: str) -> None:
     """
     if not SIGNAL_USER:
         logger.error("SIGNAL_USER not set (check Keychain or env var) — cannot receive messages")
-        _write_health("error", "no_signal_user", "SIGNAL_USER not configured")
+        _record_failure("no_signal_user", "SIGNAL_USER not configured")
         return
 
     init_db(db_path)
     messages = receive_messages()
 
     if messages is None:
-        _write_health("error", "not_registered", f"signal-cli account {SIGNAL_USER} is not registered")
+        err = _LAST_RECEIVE_ERROR or {}
+        _record_failure(
+            err.get("error", "receive_failed"),
+            err.get("message", "signal-cli receive failed with no detail"),
+        )
         return
 
-    _write_health("ok")
+    # Successful round-trip to signal-cli (even if no messages arrived).
+    _record_success()
 
     image_batches, non_image_messages = _batch_image_messages(messages)
 

--- a/pipeline/status.py
+++ b/pipeline/status.py
@@ -186,7 +186,13 @@ def check_log_freshness() -> list[str]:
 
 
 def check_signal_health() -> list[str]:
-    """Check signal-cli health from the listener's health status file."""
+    """Check signal-cli health from the listener's health status file.
+
+    Recognised statuses:
+        ok        — most recent poll succeeded
+        error     — most recent poll failed (transient)
+        degraded  — 3+ consecutive polls failed (needs user intervention)
+    """
     problems = []
     if not os.path.exists(SIGNAL_HEALTH_FILE):
         problems.append("signal-cli: health file missing (listener may not have run yet)")
@@ -199,10 +205,37 @@ def check_signal_health() -> list[str]:
         return problems
 
     status = data.get("status")
-    if status == "error":
-        error_type = data.get("error", "unknown")
-        message = data.get("message", "")
-        problems.append(f"signal-cli: {error_type} — {message}")
+    error_type = data.get("error", "unknown")
+    message = data.get("message", "")
+    streak = int(data.get("consecutive_failures", 0) or 0)
+
+    def _last_success_suffix() -> str:
+        success_str = data.get("last_success_at", "")
+        if not success_str:
+            return ""
+        try:
+            last_success = datetime.fromisoformat(success_str)
+            age = (datetime.now(timezone.utc) - last_success).total_seconds() / 60
+            if age < 60:
+                return f" (last healthy {int(age)}m ago)"
+            return f" (last healthy {int(age // 60)}h{int(age % 60)}m ago)"
+        except ValueError:
+            return ""
+
+    if status == "degraded":
+        problems.append(
+            f"signal-cli: DEGRADED after {streak} consecutive failures "
+            f"({error_type}) — run `python pipeline/signal_doctor.py` to diagnose"
+            + _last_success_suffix()
+        )
+        if message:
+            problems.append(f"  └─ {message}")
+    elif status == "error":
+        problems.append(
+            f"signal-cli: {error_type} — {message}" + _last_success_suffix()
+        )
+        if streak > 1:
+            problems.append(f"  └─ {streak} consecutive failures so far")
     elif status == "ok":
         ts_str = data.get("timestamp", "")
         if ts_str:

--- a/src/mcp_knowledge/api.py
+++ b/src/mcp_knowledge/api.py
@@ -5,9 +5,14 @@ Endpoints:
     GET  /status       — Index health dashboard
     POST /reindex      — Trigger media archive reindex
     GET  /health       — Simple liveness check
+    POST /add-link     — Queue a URL for the pipeline (token-authed)
 """
 import asyncio
 import logging
+import os
+import sqlite3
+import sys
+from pathlib import Path
 
 from starlette.applications import Starlette
 from starlette.middleware.cors import CORSMiddleware
@@ -17,9 +22,35 @@ from starlette.routing import Route
 
 logger = logging.getLogger("mcp_knowledge.api")
 
+# Make the pipeline package importable for /add-link. api.py lives at
+# src/mcp_knowledge/api.py; the pipeline package is at the project root.
+_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
 
-def create_api(semantic_index, knowledge_base=None) -> Starlette:
-    """Create the HTTP API application."""
+
+def create_api(
+    semantic_index,
+    knowledge_base=None,
+    *,
+    api_token: str | None = None,
+    db_path: str | None = None,
+) -> Starlette:
+    """Create the HTTP API application.
+
+    Args:
+        semantic_index: Semantic search backend.
+        knowledge_base: Optional keyword search backend.
+        api_token: Shared secret required on ``/add-link`` via the
+            ``X-Crows-Nest-Token`` header. If None, read from the
+            ``CROWS_NEST_API_TOKEN`` environment variable at call time.
+            When no token is configured, ``/add-link`` returns 503.
+        db_path: SQLite path for ``/add-link``. If None, falls back to
+            ``pipeline.config.DB_PATH`` at request time.
+    """
+    resolved_token = api_token if api_token is not None else os.environ.get(
+        "CROWS_NEST_API_TOKEN", ""
+    )
 
     async def search(request: Request) -> JSONResponse:
         try:
@@ -65,29 +96,123 @@ def create_api(semantic_index, knowledge_base=None) -> Starlette:
     async def health(request: Request) -> JSONResponse:
         return JSONResponse({"status": "ok", "service": "crows-nest"})
 
+    async def add_link_endpoint(request: Request) -> JSONResponse:
+        if not resolved_token:
+            return JSONResponse(
+                {
+                    "error": (
+                        "/add-link is disabled: set CROWS_NEST_API_TOKEN "
+                        "to enable it"
+                    )
+                },
+                status_code=503,
+            )
+
+        supplied = request.headers.get("X-Crows-Nest-Token", "")
+        if supplied != resolved_token:
+            return JSONResponse({"error": "invalid token"}, status_code=401)
+
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+
+        url = (body or {}).get("url")
+        if not url or not isinstance(url, str):
+            return JSONResponse(
+                {"error": "url is required (string)"}, status_code=400,
+            )
+
+        context = body.get("context")
+        source_type = body.get("source_type") or "http"
+
+        # Imported lazily so tests that don't exercise this route don't
+        # incur the pipeline import cost.
+        try:
+            from pipeline.db import add_link, init_db
+            from pipeline.content_types import classify_url
+            from pipeline.config import DB_PATH as _DEFAULT_DB_PATH
+        except ImportError as exc:
+            logger.exception("pipeline import failed for /add-link")
+            return JSONResponse(
+                {"error": f"pipeline unavailable: {exc}"},
+                status_code=500,
+            )
+
+        target_db = db_path or _DEFAULT_DB_PATH
+        content_type = classify_url(url)
+
+        def _insert() -> int:
+            init_db(target_db)
+            return add_link(
+                url=url,
+                source_type=source_type,
+                sender=None,
+                context=context,
+                content_type=content_type,
+                db_path=target_db,
+            )
+
+        try:
+            link_id = await asyncio.to_thread(_insert)
+        except sqlite3.IntegrityError:
+            return JSONResponse(
+                {"error": "url already queued", "url": url},
+                status_code=409,
+            )
+        except Exception as exc:
+            logger.exception("add_link failed")
+            return JSONResponse({"error": str(exc)}, status_code=500)
+
+        return JSONResponse(
+            {
+                "id": link_id,
+                "status": "queued",
+                "content_type": content_type,
+                "source_type": source_type,
+            },
+            status_code=201,
+        )
+
     app = Starlette(
         routes=[
             Route("/search", search, methods=["POST"]),
             Route("/status", status, methods=["GET"]),
             Route("/reindex", reindex, methods=["POST"]),
             Route("/health", health, methods=["GET"]),
+            Route("/add-link", add_link_endpoint, methods=["POST"]),
         ],
     )
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["app://obsidian.md", "http://localhost", "http://127.0.0.1"],
         allow_methods=["GET", "POST", "OPTIONS"],
-        allow_headers=["*"],
+        allow_headers=["*", "X-Crows-Nest-Token"],
     )
     return app
 
 
 async def start_api_server(semantic_index, knowledge_base=None,
-                           host="127.0.0.1", port=27185, log_level="info"):
-    """Start the HTTP API server as a background task."""
+                           host="127.0.0.1", port=27185, log_level="info",
+                           api_token: str | None = None,
+                           db_path: str | None = None):
+    """Start the HTTP API server as a background task.
+
+    ``api_token`` and ``db_path`` default to the environment/pipeline defaults
+    when omitted, which is the usual production path.
+    """
     import uvicorn
-    app = create_api(semantic_index, knowledge_base)
+    app = create_api(
+        semantic_index,
+        knowledge_base,
+        api_token=api_token,
+        db_path=db_path,
+    )
     config = uvicorn.Config(app, host=host, port=port, log_level=log_level)
     server = uvicorn.Server(config)
     logger.info("HTTP API starting on %s:%d", host, port)
+    if os.environ.get("CROWS_NEST_API_TOKEN"):
+        logger.info("HTTP API: /add-link enabled (token auth)")
+    else:
+        logger.info("HTTP API: /add-link disabled (set CROWS_NEST_API_TOKEN to enable)")
     await server.serve()

--- a/tests/pipeline/test_signal_doctor.py
+++ b/tests/pipeline/test_signal_doctor.py
@@ -1,0 +1,168 @@
+"""Tests for pipeline/signal_doctor.py — diagnostic CLI for signal-cli."""
+
+import json
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../pipeline"))
+
+import signal_doctor
+from signal_doctor import (
+    CheckResult,
+    check_data_directory,
+    check_receive,
+    check_signal_cli_binary,
+    check_signal_user,
+    read_health,
+    summarize_health,
+)
+
+
+# --- check_signal_user ---
+
+def test_check_signal_user_missing():
+    with patch("signal_doctor.get_secret", return_value=""):
+        r = check_signal_user()
+    assert r.ok is False
+    assert "Keychain" in r.recovery or "SIGNAL_USER" in r.recovery
+
+
+def test_check_signal_user_present():
+    with patch("signal_doctor.get_secret", return_value="+16085551234"):
+        r = check_signal_user()
+    assert r.ok is True
+    assert r.detail == "+16085551234"
+
+
+# --- check_signal_cli_binary ---
+
+def test_check_signal_cli_binary_missing():
+    with patch("signal_doctor.shutil.which", return_value=None):
+        r = check_signal_cli_binary()
+    assert r.ok is False
+    assert "install" in r.recovery.lower()
+
+
+def test_check_signal_cli_binary_present():
+    with patch("signal_doctor.shutil.which", return_value="/usr/local/bin/signal-cli"):
+        r = check_signal_cli_binary()
+    assert r.ok is True
+    assert "/usr/local/bin/signal-cli" in r.detail
+
+
+# --- check_data_directory ---
+
+def test_check_data_directory_missing(tmp_path):
+    missing = str(tmp_path / "nope")
+    with patch("signal_doctor.SIGNAL_DATA_DIR", missing):
+        r = check_data_directory()
+    assert r.ok is False
+    assert "link" in r.recovery.lower()
+
+
+def test_check_data_directory_present(tmp_path):
+    existing = str(tmp_path)
+    with patch("signal_doctor.SIGNAL_DATA_DIR", existing):
+        r = check_data_directory()
+    assert r.ok is True
+
+
+# --- check_receive ---
+
+def test_check_receive_success():
+    with patch("signal_doctor.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        r = check_receive("+16085551234")
+    assert r.ok is True
+
+
+def test_check_receive_not_registered():
+    with patch("signal_doctor.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stderr="User +16085551234 is not registered.",
+        )
+        r = check_receive("+16085551234")
+    assert r.ok is False
+    assert "not registered" in r.detail.lower()
+    assert "link" in r.recovery.lower()
+
+
+def test_check_receive_other_error():
+    with patch("signal_doctor.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(
+            returncode=2,
+            stderr="some other failure",
+        )
+        r = check_receive("+16085551234")
+    assert r.ok is False
+    assert "exit 2" in r.detail
+
+
+def test_check_receive_timeout():
+    import subprocess as _sp
+    with patch("signal_doctor.subprocess.run") as mock_run:
+        mock_run.side_effect = _sp.TimeoutExpired(cmd=["signal-cli"], timeout=10)
+        r = check_receive("+16085551234")
+    assert r.ok is False
+    assert "timed out" in r.detail.lower()
+
+
+# --- read_health / summarize_health ---
+
+def test_read_health_missing_file(tmp_path):
+    path = str(tmp_path / "signal-health.json")
+    with patch("signal_doctor.SIGNAL_HEALTH_FILE", path):
+        assert read_health() == {}
+
+
+def test_read_health_returns_parsed(tmp_path):
+    path = tmp_path / "signal-health.json"
+    path.write_text(json.dumps({"status": "ok", "timestamp": "2026-04-11T00:00:00+00:00"}))
+    with patch("signal_doctor.SIGNAL_HEALTH_FILE", str(path)):
+        health = read_health()
+    assert health["status"] == "ok"
+
+
+def test_summarize_health_empty():
+    assert "no health file" in summarize_health({})
+
+
+def test_summarize_health_error_state():
+    summary = summarize_health({
+        "status": "degraded",
+        "error": "not_registered",
+        "message": "run signal-cli register",
+        "consecutive_failures": 4,
+    })
+    assert "degraded" in summary
+    assert "not_registered" in summary
+    assert "4" in summary
+
+
+# --- run_checks composition ---
+
+def test_run_checks_skips_receive_when_prereqs_fail():
+    with (
+        patch("signal_doctor.get_secret", return_value=""),
+        patch("signal_doctor.shutil.which", return_value=None),
+        patch("signal_doctor.os.path.isdir", return_value=False),
+    ):
+        results = signal_doctor.run_checks()
+    names = [r.name for r in results]
+    assert "signal-cli receive" not in names  # skipped when prereqs fail
+
+
+def test_run_checks_runs_receive_when_prereqs_pass(tmp_path):
+    with (
+        patch("signal_doctor.get_secret", return_value="+16085551234"),
+        patch("signal_doctor.shutil.which", return_value="/usr/local/bin/signal-cli"),
+        patch("signal_doctor.SIGNAL_DATA_DIR", str(tmp_path)),
+        patch("signal_doctor.subprocess.run") as mock_run,
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        results = signal_doctor.run_checks()
+    names = [r.name for r in results]
+    assert "signal-cli receive" in names
+    assert all(r.ok for r in results)

--- a/tests/pipeline/test_signal_listener.py
+++ b/tests/pipeline/test_signal_listener.py
@@ -13,6 +13,10 @@ from signal_listener import (
     _batch_image_messages,
     receive_messages,
     _write_health,
+    _read_health,
+    _record_success,
+    _record_failure,
+    DEGRADED_FAILURE_THRESHOLD,
     resolve_sender,
 )
 
@@ -299,6 +303,42 @@ def test_receive_returns_none_on_other_fatal_error(mock_run):
 
 
 @patch("signal_listener.subprocess.run")
+def test_receive_populates_last_error_on_not_registered(mock_run):
+    """not_registered failures leave structured error info for run()."""
+    import signal_listener
+    mock_run.return_value = MagicMock(
+        returncode=1,
+        stdout="",
+        stderr="User +16124706803 is not registered.",
+    )
+    result = receive_messages()
+    assert result is None
+    assert signal_listener._LAST_RECEIVE_ERROR["error"] == "not_registered"
+    assert "register" in signal_listener._LAST_RECEIVE_ERROR["message"].lower()
+
+
+@patch("signal_listener.subprocess.run")
+def test_receive_populates_last_error_on_subprocess_exception(mock_run):
+    """Generic subprocess exceptions are classified as subprocess_error."""
+    import signal_listener
+    mock_run.side_effect = RuntimeError("boom")
+    result = receive_messages()
+    assert result is None
+    assert signal_listener._LAST_RECEIVE_ERROR["error"] == "subprocess_error"
+    assert "boom" in signal_listener._LAST_RECEIVE_ERROR["message"]
+
+
+@patch("signal_listener.subprocess.run")
+def test_receive_resets_last_error_on_success(mock_run):
+    """A success after a failure clears the error state dict."""
+    import signal_listener
+    signal_listener._LAST_RECEIVE_ERROR = {"error": "stale", "message": "old"}
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    receive_messages()
+    assert signal_listener._LAST_RECEIVE_ERROR == {}
+
+
+@patch("signal_listener.subprocess.run")
 def test_receive_returns_list_on_success(mock_run):
     """Successful signal-cli invocation returns a list (possibly empty)."""
     mock_run.return_value = MagicMock(
@@ -334,4 +374,97 @@ def test_write_health_ok(tmp_path):
     with open(health_file) as f:
         data = json.load(f)
     assert data["status"] == "ok"
+    assert "error" not in data
+
+
+# --- health state machine: record_success / record_failure / preservation ---
+
+def test_read_health_returns_empty_when_missing(tmp_path):
+    """Missing health file yields an empty dict, not an exception."""
+    health_file = str(tmp_path / "signal-health.json")
+    with patch("signal_listener.SIGNAL_HEALTH_FILE", health_file):
+        assert _read_health() == {}
+
+
+def test_read_health_returns_empty_on_corrupt_file(tmp_path):
+    """Corrupt JSON should degrade gracefully to an empty dict."""
+    health_file = tmp_path / "signal-health.json"
+    health_file.write_text("{not json")
+    with patch("signal_listener.SIGNAL_HEALTH_FILE", str(health_file)):
+        assert _read_health() == {}
+
+
+def test_record_success_writes_ok_and_resets_streak(tmp_path):
+    health_file = str(tmp_path / "signal-health.json")
+    with patch("signal_listener.SIGNAL_HEALTH_FILE", health_file):
+        # Pretend we had 2 failures already.
+        _write_health(
+            "error", "timeout", "prior timeout",
+            consecutive_failures=2,
+        )
+        _record_success()
+
+    with open(health_file) as f:
+        data = json.load(f)
+    assert data["status"] == "ok"
+    assert data["consecutive_failures"] == 0
+    assert "last_success_at" in data
+    assert "error" not in data
+
+
+def test_record_failure_increments_streak(tmp_path):
+    health_file = str(tmp_path / "signal-health.json")
+    with patch("signal_listener.SIGNAL_HEALTH_FILE", health_file):
+        _record_failure("timeout", "first timeout")
+        with open(health_file) as f:
+            assert json.load(f)["consecutive_failures"] == 1
+
+        _record_failure("timeout", "second timeout")
+        with open(health_file) as f:
+            assert json.load(f)["consecutive_failures"] == 2
+
+
+def test_record_failure_escalates_to_degraded(tmp_path):
+    """After DEGRADED_FAILURE_THRESHOLD failures the status becomes 'degraded'."""
+    health_file = str(tmp_path / "signal-health.json")
+    with patch("signal_listener.SIGNAL_HEALTH_FILE", health_file):
+        for i in range(DEGRADED_FAILURE_THRESHOLD):
+            _record_failure("not_registered", f"fail {i}")
+
+    with open(health_file) as f:
+        data = json.load(f)
+    assert data["status"] == "degraded"
+    assert data["consecutive_failures"] == DEGRADED_FAILURE_THRESHOLD
+    assert data["error"] == "not_registered"
+
+
+def test_record_failure_preserves_last_success_at(tmp_path):
+    """The timestamp of the last healthy poll survives across failures."""
+    health_file = str(tmp_path / "signal-health.json")
+    with patch("signal_listener.SIGNAL_HEALTH_FILE", health_file):
+        _record_success()
+        with open(health_file) as f:
+            last_ok = json.load(f)["last_success_at"]
+
+        _record_failure("timeout", "boom")
+
+    with open(health_file) as f:
+        data = json.load(f)
+    assert data["last_success_at"] == last_ok
+    assert data["status"] == "error"
+
+
+def test_record_success_after_failure_clears_error(tmp_path):
+    """A successful poll after failures wipes error state and streak."""
+    health_file = str(tmp_path / "signal-health.json")
+    with patch("signal_listener.SIGNAL_HEALTH_FILE", health_file):
+        _record_failure("timeout", "failed")
+        _record_failure("timeout", "failed")
+        _record_failure("timeout", "failed")  # now degraded
+        _record_success()
+
+    with open(health_file) as f:
+        data = json.load(f)
+    assert data["status"] == "ok"
+    assert data["consecutive_failures"] == 0
     assert "error" not in data

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -101,3 +101,132 @@ def test_search_empty_results():
     r = client.post("/search", json={"query": "nothing"})
     assert r.status_code == 200
     assert r.json()["results"] == []
+
+
+# ---------------------------------------------------------------------------
+# /add-link tests
+# ---------------------------------------------------------------------------
+
+def _add_link_client(tmp_path, *, token="test-token"):
+    """Build a test client with a per-test SQLite db and a known token."""
+    mock_semantic = MagicMock()
+    mock_semantic.search.return_value = []
+    mock_semantic.get_status.return_value = {}
+    db_path = str(tmp_path / "test.db")
+    app = create_api(
+        semantic_index=mock_semantic,
+        api_token=token,
+        db_path=db_path,
+    )
+    return TestClient(app), db_path
+
+
+def test_add_link_requires_token(tmp_path):
+    client, _ = _add_link_client(tmp_path)
+    r = client.post("/add-link", json={"url": "https://example.com"})
+    assert r.status_code == 401
+
+
+def test_add_link_rejects_bad_token(tmp_path):
+    client, _ = _add_link_client(tmp_path)
+    r = client.post(
+        "/add-link",
+        json={"url": "https://example.com"},
+        headers={"X-Crows-Nest-Token": "wrong"},
+    )
+    assert r.status_code == 401
+
+
+def test_add_link_disabled_when_token_blank(tmp_path):
+    """Blank token means the endpoint is administratively disabled."""
+    client, _ = _add_link_client(tmp_path, token="")
+    r = client.post(
+        "/add-link",
+        json={"url": "https://example.com"},
+        headers={"X-Crows-Nest-Token": ""},
+    )
+    assert r.status_code == 503
+
+
+def test_add_link_requires_url(tmp_path):
+    client, _ = _add_link_client(tmp_path)
+    r = client.post(
+        "/add-link",
+        json={},
+        headers={"X-Crows-Nest-Token": "test-token"},
+    )
+    assert r.status_code == 400
+
+
+def test_add_link_rejects_non_string_url(tmp_path):
+    client, _ = _add_link_client(tmp_path)
+    r = client.post(
+        "/add-link",
+        json={"url": 42},
+        headers={"X-Crows-Nest-Token": "test-token"},
+    )
+    assert r.status_code == 400
+
+
+def test_add_link_queues_url(tmp_path):
+    client, db_path = _add_link_client(tmp_path)
+    r = client.post(
+        "/add-link",
+        json={"url": "https://example.com", "context": "from the API"},
+        headers={"X-Crows-Nest-Token": "test-token"},
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["status"] == "queued"
+    assert body["source_type"] == "http"
+    assert body["content_type"]  # classify_url returned something
+    assert isinstance(body["id"], int)
+
+    # Verify the row landed in the database with the expected source_type.
+    import sqlite3
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT url, source_type, context, status FROM links WHERE id = ?",
+            (body["id"],),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row == ("https://example.com", "http", "from the API", "pending")
+
+
+def test_add_link_honours_source_type_override(tmp_path):
+    client, _ = _add_link_client(tmp_path)
+    r = client.post(
+        "/add-link",
+        json={"url": "https://example.com/2", "source_type": "shortcut"},
+        headers={"X-Crows-Nest-Token": "test-token"},
+    )
+    assert r.status_code == 201
+    assert r.json()["source_type"] == "shortcut"
+
+
+def test_add_link_duplicate_returns_409(tmp_path):
+    client, _ = _add_link_client(tmp_path)
+    headers = {"X-Crows-Nest-Token": "test-token"}
+    first = client.post(
+        "/add-link", json={"url": "https://dup.example"}, headers=headers,
+    )
+    assert first.status_code == 201
+    second = client.post(
+        "/add-link", json={"url": "https://dup.example"}, headers=headers,
+    )
+    assert second.status_code == 409
+
+
+def test_add_link_invalid_json(tmp_path):
+    client, _ = _add_link_client(tmp_path)
+    r = client.post(
+        "/add-link",
+        content=b"not json",
+        headers={
+            "X-Crows-Nest-Token": "test-token",
+            "Content-Type": "application/json",
+        },
+    )
+    assert r.status_code == 400


### PR DESCRIPTION
Give the pipeline two independent recoveries when signal-cli auth fails
instead of leaving ingestion stopped:

Signal hardening:
- signal_listener.py tracks consecutive_failures and last_success_at in
  the health file, escalates to "degraded" after 3 failures, and
  classifies transient subprocess/timeout errors distinctly from
  "not registered" so status.py can surface the right recovery hint.
- New pipeline/signal_doctor.py diagnostic CLI checks SIGNAL_USER,
  signal-cli binary, data directory, and a live receive round-trip,
  printing targeted recovery steps for each failing check.
- status.py --health surfaces the new degraded state with the failure
  streak and time-since-last-healthy.

HTTP /add-link endpoint:
- POST /add-link on the existing HTTP API queues a URL into the same
  pending pipeline as the Signal listener, gated by a shared-secret
  CROWS_NEST_API_TOKEN passed in the X-Crows-Nest-Token header.
- Returns 201 on queue, 409 on duplicate, 401/503 on auth/config, 400
  on bad input. Foundation for iOS Shortcuts, bookmarklets, and any
  other Signal-independent capture workflow.

Includes 33 new tests (signal_listener health state machine,
signal_doctor checks, /add-link token auth and DB write).

https://claude.ai/code/session_01FsfGjXaxy3gT9993sLRdTt