### PR TITLE
feat: add streamable-http transport support

### DIFF
--- a/src/mcp_knowledge/config.py
+++ b/src/mcp_knowledge/config.py
@@ -63,3 +63,7 @@ MCP_TRANSPORT = os.environ.get("MCP_TRANSPORT", "stdio")
 MCP_SSE_HOST = os.environ.get("MCP_SSE_HOST", "127.0.0.1")
 MCP_SSE_PORT = int(os.environ.get("MCP_SSE_PORT", "27185"))
 
+# Streamable-HTTP transport settings (MCP_HOST/MCP_PORT for streamable-http)
+MCP_HOST = os.environ.get("MCP_HOST", "127.0.0.1")
+MCP_PORT = int(os.environ.get("MCP_PORT", "27185"))
+

--- a/src/mcp_knowledge/server.py
+++ b/src/mcp_knowledge/server.py
@@ -45,8 +45,8 @@ except ImportError as _rss_exc:
 
 mcp = FastMCP(
     config.SERVER_NAME,
-    host=config.MCP_SSE_HOST,
-    port=config.MCP_SSE_PORT,
+    host=config.MCP_HOST,
+    port=config.MCP_PORT,
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add MCP_HOST/MCP_PORT env vars to config.py
- Pass host/port to FastMCP constructor
- Enables `MCP_TRANSPORT=streamable-http` for M2 dashboard access

## Test plan
- [x] 197/197 tests passing
- [ ] Manual: `MCP_TRANSPORT=streamable-http MCP_PORT=27185 python -m mcp_knowledge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)