### PR TITLE
feat: LLM-based weekly links categorization

### DIFF
--- a/pipeline/summarizer.py
+++ b/pipeline/summarizer.py
@@ -1218,10 +1218,12 @@ def _reclassify_entries(
                     break
 
             if other_idx is not None:
-                result.insert(other_idx, f"\n{target_header}\n")
-                result.insert(other_idx + 1, removed_line)
+                result.insert(other_idx, "\n")
+                result.insert(other_idx + 1, target_header)
+                result.insert(other_idx + 2, removed_line)
             else:
-                result.append(f"\n{target_header}\n")
+                result.append("\n")
+                result.append(target_header)
                 result.append(removed_line)
 
     return result
@@ -1266,12 +1268,28 @@ def _append_to_weekly_log(
         with open(filepath, "w", encoding="utf-8") as f:
             f.write(content)
 
-    section = categorize_from_tags(tags or [], content_type)
+    with open(filepath, "r", encoding="utf-8") as f:
+        file_content = f.read()
+
+    # Ask the LLM to categorize, seeing existing sections for context
+    existing_sections = _parse_weekly_sections(file_content)
+    llm_result = _categorize_via_llm(
+        title=title,
+        url=url,
+        content_type=content_type,
+        tags=tags or [],
+        existing_sections=existing_sections,
+    )
+    section = llm_result["category"]
+
     entry_line = f"- {capture_date.isoformat()} \u2014 [[{sanitize_title(title)}]] \u00b7 [{content_type}]({url}) \u00b7 via {source}\n"
 
-    with open(filepath, "r", encoding="utf-8") as f:
-        lines = f.readlines()
+    lines = file_content.splitlines(keepends=True)
 
+    # Apply any reclassifications the LLM suggested
+    lines = _reclassify_entries(lines, llm_result.get("reclassify", []))
+
+    # Insert the new entry under the appropriate section
     section_header = f"## {section}\n"
     inserted = False
     for i, line in enumerate(lines):
@@ -1289,8 +1307,6 @@ def _append_to_weekly_log(
                 break
         if other_idx is not None:
             lines.insert(other_idx, f"\n{section_header}\n")
-            # list.insert adds one element regardless of embedded newlines,
-            # so the entry goes at other_idx + 1 (right after the header).
             lines.insert(other_idx + 1, entry_line)
         else:
             lines.append(f"\n{section_header}\n")

--- a/pipeline/summarizer.py
+++ b/pipeline/summarizer.py
@@ -1042,6 +1042,12 @@ Rules:
         return fallback
 
     category = parsed.get("category", "Other")
+    # Sanitize category: only allow safe characters for a markdown header.
+    # Strip anything that could inject markdown structure or links.
+    if isinstance(category, str):
+        category = re.sub(r"[^\w &/'-]", "", category).strip()[:50]
+    if not category or not isinstance(category, str):
+        category = "Other"
     reclassify = parsed.get("reclassify", [])
 
     # Sanitize reclassify: must be a list of dicts with title+to keys
@@ -1063,8 +1069,6 @@ def _parse_weekly_sections(content: str) -> dict[str, list[str]]:
     Scans for ``## Section Name`` headers and extracts wikilink titles
     (``[[Title]]``) from entry lines under each section.
     """
-    import re
-
     sections: dict[str, list[str]] = {}
     current_section: str | None = None
 

--- a/pipeline/summarizer.py
+++ b/pipeline/summarizer.py
@@ -918,71 +918,6 @@ def write_obsidian_note(title: str, frontmatter: str, body: str,
 
 # --- Weekly Links Log ---
 
-# Ordered tag-to-category rules. First matching rule wins.
-# Each rule is (set_of_tags, category_name).
-TAG_CATEGORY_RULES: list[tuple[set[str], str]] = [
-    (
-        {"marathon-game", "marathon-guide", "marathon-solo", "marathon-farming"},
-        "Gaming",
-    ),
-    (
-        {"gaming-tips", "pvp-strategy", "extraction-games", "game-mechanics",
-         "indie-games", "character-builds", "speedrun"},
-        "Gaming",
-    ),
-    (
-        {"claude-code", "ai-agents", "mcp-server", "prompt-engineering",
-         "llm-tools", "context-engineering", "workflow-automation",
-         "developer-tools", "ai-automation", "harness-engineering",
-         "browser-automation", "local-llm", "ai-workflows", "coding-agents"},
-        "AI & Dev Tools",
-    ),
-    (
-        {"horror-film", "horror-movies", "psychological-horror", "analog-horror",
-         "found-footage", "cosmic-horror", "supernatural-horror", "horror-games",
-         "movie-review", "film-review", "movie-recommendation", "thriller",
-         "horror-nostalgia", "horror-content"},
-        "Horror & Film",
-    ),
-    (
-        {"career-coaching", "burnout-recovery", "professional-development",
-         "leadership", "workplace-culture", "management-leadership",
-         "employee-engagement", "toxic-workplace", "executive-education"},
-        "Work & Leadership",
-    ),
-    (
-        {"activism", "surveillance-capitalism", "ai-ethics", "corporate-lobbying",
-         "regulatory-capture", "government-technology", "digital-rights",
-         "content-moderation", "deepfake", "ai-satire", "privatization"},
-        "Politics & Society",
-    ),
-    (
-        {"relationships", "personal-growth", "self-care", "philosophy",
-         "self-love", "existentialism", "communication-skills",
-         "emotional-intelligence", "heartbreak", "dating-advice"},
-        "Personal Growth",
-    ),
-    (
-        {"3d-printing", "self-hosting", "open-source", "single-board-computer",
-         "home-lab", "video-codec", "web-development", "right-to-repair",
-         "iphone-customization", "open-source-hardware"},
-        "Tech & Hardware",
-    ),
-    (
-        {"home-cleaning", "desk-organization", "phone-accessories",
-         "interior-design", "room-divider", "fashion-trends", "workspace-setup",
-         "sustainable-products"},
-        "Products & Home",
-    ),
-]
-
-# Content-type fallback for entries with no matching tags.
-CONTENT_TYPE_FALLBACK_MAP = {
-    "podcast": "News & Current Events",
-    "audio": "News & Current Events",
-    "image": "Images",
-}
-
 WEEKLY_LOG_TEMPLATE = """---
 title: "Weekly Links — {week_label}"
 created: {created}
@@ -999,21 +934,6 @@ tags:
 ## Other
 """
 
-
-def categorize_from_tags(
-    tags: list[str],
-    content_type: str = "web_page",
-) -> str:
-    """Determine a topic category from a note's tags.
-
-    Checks tags against TAG_CATEGORY_RULES in priority order.
-    Falls back to content-type mapping, then "Other".
-    """
-    tag_set = set(tags)
-    for rule_tags, category in TAG_CATEGORY_RULES:
-        if tag_set & rule_tags:
-            return category
-    return CONTENT_TYPE_FALLBACK_MAP.get(content_type, "Other")
 
 
 def _categorize_via_llm(

--- a/pipeline/summarizer.py
+++ b/pipeline/summarizer.py
@@ -1163,6 +1163,70 @@ def _parse_weekly_sections(content: str) -> dict[str, list[str]]:
     return sections
 
 
+def _reclassify_entries(
+    lines: list[str],
+    reclassify: list[dict[str, str]],
+) -> list[str]:
+    """Move entries between sections in a weekly log lines array.
+
+    Each item in *reclassify* is ``{"title": "...", "to": "Section Name"}``.
+    The entry line containing ``[[title]]`` is removed from its current
+    position and appended under the target ``## Section Name`` header,
+    which is created before ``## Other`` if it doesn't exist yet.
+
+    Returns a new list; the original is not mutated.
+    """
+    if not reclassify:
+        return lines
+
+    result = list(lines)  # shallow copy
+
+    for instruction in reclassify:
+        title = instruction.get("title", "")
+        target_section = instruction.get("to", "")
+        if not title or not target_section:
+            continue
+
+        # Find and remove the entry line containing [[title]]
+        marker = f"[[{title}]]"
+        removed_line = None
+        for i, line in enumerate(result):
+            if marker in line:
+                removed_line = result.pop(i)
+                break
+
+        if removed_line is None:
+            continue
+
+        # Find the target section header
+        target_header = f"## {target_section}\n"
+        target_idx = None
+        for i, line in enumerate(result):
+            if line == target_header:
+                target_idx = i
+                break
+
+        if target_idx is not None:
+            # Insert after the header
+            result.insert(target_idx + 1, removed_line)
+        else:
+            # Create the section before ## Other
+            other_idx = None
+            for i, line in enumerate(result):
+                if line == "## Other\n":
+                    other_idx = i
+                    break
+
+            if other_idx is not None:
+                result.insert(other_idx, f"\n{target_header}\n")
+                result.insert(other_idx + 1, removed_line)
+            else:
+                result.append(f"\n{target_header}\n")
+                result.append(removed_line)
+
+    return result
+
+
 def _append_to_weekly_log(
     inbox_dir: str,
     title: str,

--- a/pipeline/summarizer.py
+++ b/pipeline/summarizer.py
@@ -1137,6 +1137,32 @@ Rules:
     return {"category": category, "reclassify": reclassify}
 
 
+def _parse_weekly_sections(content: str) -> dict[str, list[str]]:
+    """Parse a weekly log file into {section_name: [entry_titles]}.
+
+    Scans for ``## Section Name`` headers and extracts wikilink titles
+    (``[[Title]]``) from entry lines under each section.
+    """
+    import re
+
+    sections: dict[str, list[str]] = {}
+    current_section: str | None = None
+
+    for line in content.splitlines():
+        header_match = re.match(r"^## (.+)$", line)
+        if header_match:
+            current_section = header_match.group(1).strip()
+            sections[current_section] = []
+            continue
+
+        if current_section is not None:
+            wikilink_match = re.search(r"\[\[([^\]]+)\]\]", line)
+            if wikilink_match:
+                sections[current_section].append(wikilink_match.group(1))
+
+    return sections
+
+
 def _append_to_weekly_log(
     inbox_dir: str,
     title: str,

--- a/pipeline/summarizer.py
+++ b/pipeline/summarizer.py
@@ -1016,6 +1016,127 @@ def categorize_from_tags(
     return CONTENT_TYPE_FALLBACK_MAP.get(content_type, "Other")
 
 
+def _categorize_via_llm(
+    title: str,
+    url: str,
+    content_type: str,
+    tags: list[str],
+    existing_sections: dict[str, list[str]],
+) -> dict:
+    """Ask Haiku to pick the best weekly-log section for a new entry.
+
+    Prefers consolidating into existing sections over creating new ones.
+    Also surfaces items from Other that could be reclassified now that a
+    related section exists.
+
+    Returns:
+        {"category": str, "reclassify": [{"title": str, "to": str}, ...]}
+    Fallback (on any failure):
+        {"category": "Other", "reclassify": []}
+    """
+    fallback = {"category": "Other", "reclassify": []}
+
+    api_key = get_secret("OPENROUTER_API_KEY")
+    if not api_key:
+        logger.warning("OPENROUTER_API_KEY not found, skipping LLM categorization")
+        return fallback
+
+    # Build a compact view of existing sections and their entries
+    sections_summary = "\n".join(
+        f"  - {name}: {len(entries)} item(s)"
+        + (f" (e.g. {entries[0]!r})" if entries else "")
+        for name, entries in existing_sections.items()
+    )
+
+    # Items currently under Other that could be reclassified
+    other_entries = existing_sections.get("Other", [])
+    other_list = "\n".join(f"  - {t}" for t in other_entries) if other_entries else "  (none)"
+
+    tags_str = ", ".join(tags) if tags else "(none)"
+
+    prompt = f"""You are categorizing a saved link for a weekly reading log.
+
+New item:
+  Title: {title}
+  URL: {url}
+  Content type: {content_type}
+  Tags: {tags_str}
+
+Existing sections in this week's log:
+{sections_summary}
+
+Items currently in "Other" (potential reclassification candidates):
+{other_list}
+
+Your task:
+1. Pick the best section for the new item. STRONGLY prefer an existing section over creating a new one. Only name a new section if the item clearly belongs to a topic that is not covered by any existing section.
+2. Optionally, list up to 2 items from "Other" that should be moved to a better section now that context exists.
+
+Respond with ONLY a JSON object in this exact format:
+{{
+  "category": "Section Name",
+  "reclassify": [
+    {{"title": "title of Other item", "to": "destination section"}}
+  ]
+}}
+
+Rules:
+- "category" must be a short title-case label (2-5 words).
+- "reclassify" may be an empty array if nothing in Other needs moving.
+- Do not include any explanation outside the JSON.
+"""
+
+    payload = json.dumps({
+        "model": OPENROUTER_MODEL,
+        "messages": [
+            {"role": "user", "content": prompt},
+        ],
+        "temperature": 0.2,
+        "max_tokens": 200,
+    }).encode("utf-8")
+
+    try:
+        req = urllib.request.Request(
+            OPENROUTER_API_URL,
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {api_key}",
+                "HTTP-Referer": "https://github.com/crows-nest-pipeline/crows-nest",
+                "X-Title": "Crow's Nest Pipeline",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            raw = resp.read().decode("utf-8")
+
+        response = json.loads(raw)
+        assistant_text = response["choices"][0]["message"]["content"]
+    except Exception as exc:
+        logger.warning("LLM categorization API call failed (non-fatal): %s", exc)
+        return fallback
+
+    parsed = _extract_json(assistant_text)
+    if parsed is None or "category" not in parsed:
+        logger.warning("LLM categorization returned unparseable response, using fallback")
+        return fallback
+
+    category = parsed.get("category", "Other")
+    reclassify = parsed.get("reclassify", [])
+
+    # Sanitize reclassify: must be a list of dicts with title+to keys
+    if not isinstance(reclassify, list):
+        reclassify = []
+    reclassify = [
+        r for r in reclassify
+        if isinstance(r, dict) and "title" in r and "to" in r
+    ]
+
+    logger.info("LLM categorization: '%s' -> section '%s', reclassify=%d item(s)",
+                title, category, len(reclassify))
+    return {"category": category, "reclassify": reclassify}
+
+
 def _append_to_weekly_log(
     inbox_dir: str,
     title: str,

--- a/tests/test_weekly_log.py
+++ b/tests/test_weekly_log.py
@@ -372,6 +372,48 @@ def test_categorize_via_llm_falls_back_on_api_error():
     assert result == {"category": "Other", "reclassify": []}
 
 
+def test_categorize_via_llm_sanitizes_adversarial_category():
+    """Category with newlines or injection attempts is sanitized."""
+    existing_sections = {"Other": []}
+
+    # Simulate LLM returning a category with newlines (prompt injection attempt)
+    adversarial_category = "Other\n- 2026-01-01 — [[Injected]] · [web](http://evil.com) · via attacker"
+    mock_resp = _make_openrouter_response(adversarial_category)
+
+    with patch("pipeline.summarizer.get_secret", return_value="fake-key"), \
+         patch("urllib.request.urlopen", return_value=mock_resp):
+        result = _categorize_via_llm(
+            title="Test",
+            url="https://example.com",
+            content_type="web_page",
+            tags=[],
+            existing_sections=existing_sections,
+        )
+
+    # Newlines stripped, no injection possible
+    assert "\n" not in result["category"]
+    assert "[[Injected]]" not in result["category"]
+    assert len(result["category"]) <= 50
+
+
+def test_categorize_via_llm_empty_category_falls_back():
+    """Empty or whitespace-only category falls back to Other."""
+    existing_sections = {"Other": []}
+    mock_resp = _make_openrouter_response("   ")
+
+    with patch("pipeline.summarizer.get_secret", return_value="fake-key"), \
+         patch("urllib.request.urlopen", return_value=mock_resp):
+        result = _categorize_via_llm(
+            title="Test",
+            url="https://example.com",
+            content_type="web_page",
+            tags=[],
+            existing_sections=existing_sections,
+        )
+
+    assert result["category"] == "Other"
+
+
 def test_categorize_via_llm_returns_reclassify_items():
     """LLM response with reclassify items is returned correctly."""
     existing_sections = {

--- a/tests/test_weekly_log.py
+++ b/tests/test_weekly_log.py
@@ -12,7 +12,6 @@ from pipeline.summarizer import (
     _categorize_via_llm,
     _parse_weekly_sections,
     _reclassify_entries,
-    categorize_from_tags,
 )
 
 

--- a/tests/test_weekly_log.py
+++ b/tests/test_weekly_log.py
@@ -11,6 +11,7 @@ from pipeline.summarizer import (
     _append_to_weekly_log,
     _categorize_via_llm,
     _parse_weekly_sections,
+    _reclassify_entries,
     categorize_from_tags,
 )
 
@@ -265,6 +266,71 @@ title: "Weekly Links — 2026-W14"
 """
     result = _parse_weekly_sections(content)
     assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# _reclassify_entries tests
+# ---------------------------------------------------------------------------
+
+def test_reclassify_moves_entry_between_sections():
+    """Entry is removed from Other and placed under the target section."""
+    lines = [
+        "## AI & Dev Tools\n",
+        "- 2026-03-30 — [[Claude Tips]] · [youtube](https://yt.com/1) · via ingest-api\n",
+        "\n",
+        "## Other\n",
+        "- 2026-03-31 — [[LLM Patterns]] · [web_page](https://ex.com) · via cli\n",
+        "- 2026-03-31 — [[Random Link]] · [web_page](https://ex.com/r) · via cli\n",
+    ]
+    reclassify = [{"title": "LLM Patterns", "to": "AI & Dev Tools"}]
+    result = _reclassify_entries(lines, reclassify)
+
+    text = "".join(result)
+    # LLM Patterns should now be under AI & Dev Tools
+    ai_section = text.split("## AI & Dev Tools")[1].split("## ")[0]
+    assert "[[LLM Patterns]]" in ai_section
+    # And removed from Other
+    other_section = text.split("## Other")[1]
+    assert "[[LLM Patterns]]" not in other_section
+    assert "[[Random Link]]" in other_section
+
+
+def test_reclassify_creates_new_section_before_other():
+    """If the target section doesn't exist, it's created before Other."""
+    lines = [
+        "## Other\n",
+        "- 2026-03-31 — [[Horror Movie]] · [web_page](https://ex.com) · via cli\n",
+    ]
+    reclassify = [{"title": "Horror Movie", "to": "Horror & Film"}]
+    result = _reclassify_entries(lines, reclassify)
+
+    text = "".join(result)
+    assert "## Horror & Film" in text
+    # New section should appear before Other
+    horror_pos = text.index("## Horror & Film")
+    other_pos = text.index("## Other")
+    assert horror_pos < other_pos
+    # Entry moved
+    horror_section = text.split("## Horror & Film")[1].split("## ")[0]
+    assert "[[Horror Movie]]" in horror_section
+
+
+def test_reclassify_no_match_is_noop():
+    """If the title doesn't match any entry, lines are unchanged."""
+    lines = [
+        "## Other\n",
+        "- 2026-03-31 — [[Something]] · [web_page](https://ex.com) · via cli\n",
+    ]
+    reclassify = [{"title": "Nonexistent Title", "to": "AI & Dev Tools"}]
+    result = _reclassify_entries(lines, reclassify)
+    assert result == lines
+
+
+def test_reclassify_empty_instructions():
+    """Empty reclassify list returns lines unchanged."""
+    lines = ["## Other\n", "- entry\n"]
+    result = _reclassify_entries(lines, [])
+    assert result == lines
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_weekly_log.py
+++ b/tests/test_weekly_log.py
@@ -16,17 +16,26 @@ from pipeline.summarizer import (
 )
 
 
+def _mock_llm(category, reclassify=None):
+    """Return a patch context that mocks _categorize_via_llm to return given category."""
+    return patch(
+        "pipeline.summarizer._categorize_via_llm",
+        return_value={"category": category, "reclassify": reclassify or []},
+    )
+
+
 def test_creates_weekly_log_on_first_capture(tmp_path):
     """First capture of the week creates the weekly log file."""
-    _append_to_weekly_log(
-        inbox_dir=str(tmp_path),
-        title="Test Article",
-        url="https://example.com/article",
-        content_type="web_page",
-        source="ingest-api",
-        tags=["career-coaching", "burnout-recovery"],
-        capture_date=date(2026, 3, 30),
-    )
+    with _mock_llm("Work & Leadership"):
+        _append_to_weekly_log(
+            inbox_dir=str(tmp_path),
+            title="Test Article",
+            url="https://example.com/article",
+            content_type="web_page",
+            source="ingest-api",
+            tags=["career-coaching", "burnout-recovery"],
+            capture_date=date(2026, 3, 30),
+        )
 
     log_path = tmp_path / "Weekly Links — 2026-W14.md"
     assert log_path.exists()
@@ -41,45 +50,47 @@ def test_creates_weekly_log_on_first_capture(tmp_path):
 
 def test_appends_to_existing_weekly_log(tmp_path):
     """Second capture appends to existing file under correct section."""
-    _append_to_weekly_log(
-        inbox_dir=str(tmp_path),
-        title="First Video",
-        url="https://youtube.com/watch?v=123",
-        content_type="youtube",
-        source="ingest-api",
-        tags=["claude-code", "ai-agents"],
-        capture_date=date(2026, 3, 30),
-    )
-    _append_to_weekly_log(
-        inbox_dir=str(tmp_path),
-        title="Second Article",
-        url="https://example.com/news",
-        content_type="web_page",
-        source="ingest-api",
-        tags=["horror-film", "movie-review"],
-        capture_date=date(2026, 3, 31),
-    )
+    with _mock_llm("AI & Dev Tools"):
+        _append_to_weekly_log(
+            inbox_dir=str(tmp_path),
+            title="First Video",
+            url="https://youtube.com/watch?v=123",
+            content_type="youtube",
+            source="ingest-api",
+            tags=["claude-code", "ai-agents"],
+            capture_date=date(2026, 3, 30),
+        )
+    with _mock_llm("Horror & Film"):
+        _append_to_weekly_log(
+            inbox_dir=str(tmp_path),
+            title="Second Article",
+            url="https://example.com/news",
+            content_type="web_page",
+            source="ingest-api",
+            tags=["horror-film", "movie-review"],
+            capture_date=date(2026, 3, 31),
+        )
 
     log_path = tmp_path / "Weekly Links — 2026-W14.md"
     content = log_path.read_text()
     assert "[[First Video]]" in content
     assert "[[Second Article]]" in content
-    # Each should be in its own section
     assert "## AI & Dev Tools" in content
     assert "## Horror & Film" in content
 
 
 def test_wikilink_uses_sanitized_title(tmp_path):
     """Wikilinks should use the sanitized title to match the actual filename."""
-    _append_to_weekly_log(
-        inbox_dir=str(tmp_path),
-        title="Claude How-To: From Basics to Advanced",
-        url="https://example.com/video",
-        content_type="social_video",
-        source="cli",
-        tags=["claude-code"],
-        capture_date=date(2026, 3, 30),
-    )
+    with _mock_llm("AI & Dev Tools"):
+        _append_to_weekly_log(
+            inbox_dir=str(tmp_path),
+            title="Claude How-To: From Basics to Advanced",
+            url="https://example.com/video",
+            content_type="social_video",
+            source="cli",
+            tags=["claude-code"],
+            capture_date=date(2026, 3, 30),
+        )
 
     content = (tmp_path / "Weekly Links — 2026-W14.md").read_text()
     assert "[[Claude How-To From Basics to Advanced]]" in content
@@ -88,69 +99,53 @@ def test_wikilink_uses_sanitized_title(tmp_path):
 
 def test_wikilink_preserves_collision_suffix(tmp_path):
     """When caller passes a filename stem with collision suffix, wikilink uses it as-is."""
-    _append_to_weekly_log(
-        inbox_dir=str(tmp_path),
-        title="Duplicate Title (1)",
-        url="https://example.com/dup",
-        content_type="web_page",
-        source="ingest-api",
-        tags=[],
-        capture_date=date(2026, 3, 30),
-    )
+    with _mock_llm("Other"):
+        _append_to_weekly_log(
+            inbox_dir=str(tmp_path),
+            title="Duplicate Title (1)",
+            url="https://example.com/dup",
+            content_type="web_page",
+            source="ingest-api",
+            tags=[],
+            capture_date=date(2026, 3, 30),
+        )
 
     content = (tmp_path / "Weekly Links — 2026-W14.md").read_text()
     assert "[[Duplicate Title (1)]]" in content
 
 
-def test_categorize_from_tags_priority():
-    """First matching rule wins when tags span multiple categories."""
-    # Marathon-specific tags should match Gaming, not the broader gaming rule
-    assert categorize_from_tags(["marathon-game", "pvp-strategy"]) == "Gaming"
-    # AI tags win
-    assert categorize_from_tags(["claude-code", "prompt-engineering"]) == "AI & Dev Tools"
-    # Horror tags
-    assert categorize_from_tags(["horror-film", "psychological-horror"]) == "Horror & Film"
-    # Work tags
-    assert categorize_from_tags(["burnout-recovery", "career-coaching"]) == "Work & Leadership"
-
-
-def test_categorize_from_tags_fallback():
-    """No matching tags falls back to content-type, then Other."""
-    assert categorize_from_tags([], "podcast") == "News & Current Events"
-    assert categorize_from_tags([], "image") == "Images"
-    assert categorize_from_tags([], "web_page") == "Other"
-    assert categorize_from_tags([]) == "Other"
-
-
 def test_dynamic_section_creation(tmp_path):
     """New sections are created dynamically before Other."""
-    _append_to_weekly_log(
-        inbox_dir=str(tmp_path),
-        title="AI Tool",
-        url="https://example.com/ai",
-        content_type="social_video",
-        source="cli",
-        tags=["claude-code"],
-        capture_date=date(2026, 3, 30),
-    )
-    _append_to_weekly_log(
-        inbox_dir=str(tmp_path),
-        title="Horror Movie",
-        url="https://example.com/horror",
-        content_type="social_video",
-        source="ingest-api",
-        tags=["horror-film"],
-        capture_date=date(2026, 3, 31),
-    )
-    _append_to_weekly_log(
-        inbox_dir=str(tmp_path),
-        title="Random Link",
-        url="https://example.com/random",
-        content_type="web_page",
-        source="ingest-api",
-        tags=[],
-        capture_date=date(2026, 3, 31),
-    )
+    with _mock_llm("AI & Dev Tools"):
+        _append_to_weekly_log(
+            inbox_dir=str(tmp_path),
+            title="AI Tool",
+            url="https://example.com/ai",
+            content_type="social_video",
+            source="cli",
+            tags=["claude-code"],
+            capture_date=date(2026, 3, 30),
+        )
+    with _mock_llm("Horror & Film"):
+        _append_to_weekly_log(
+            inbox_dir=str(tmp_path),
+            title="Horror Movie",
+            url="https://example.com/horror",
+            content_type="social_video",
+            source="ingest-api",
+            tags=["horror-film"],
+            capture_date=date(2026, 3, 31),
+        )
+    with _mock_llm("Other"):
+        _append_to_weekly_log(
+            inbox_dir=str(tmp_path),
+            title="Random Link",
+            url="https://example.com/random",
+            content_type="web_page",
+            source="ingest-api",
+            tags=[],
+            capture_date=date(2026, 3, 31),
+        )
 
     content = (tmp_path / "Weekly Links — 2026-W14.md").read_text()
     # Topic sections should appear before Other
@@ -160,7 +155,6 @@ def test_dynamic_section_creation(tmp_path):
     assert ai_pos < other_pos
     assert horror_pos < other_pos
     # Entries land under their own section, not under Other
-    # split("## ")[1] gives text after the header up to the next section
     ai_section = content[ai_pos:].split("## ")[1]
     assert "[[AI Tool]]" in ai_section
     horror_section = content[horror_pos:].split("## ")[1]
@@ -173,41 +167,23 @@ def test_dynamic_section_creation(tmp_path):
 
 def test_entries_land_under_correct_section(tmp_path):
     """Multiple entries in the same category all go under the same section."""
-    for i in range(3):
-        _append_to_weekly_log(
-            inbox_dir=str(tmp_path),
-            title=f"Marathon Tip {i}",
-            url=f"https://example.com/marathon{i}",
-            content_type="social_video",
-            source="ingest-api",
-            tags=["marathon-game", "gaming-tips"],
-            capture_date=date(2026, 3, 30),
-        )
+    with _mock_llm("Gaming"):
+        for i in range(3):
+            _append_to_weekly_log(
+                inbox_dir=str(tmp_path),
+                title=f"Marathon Tip {i}",
+                url=f"https://example.com/marathon{i}",
+                content_type="social_video",
+                source="ingest-api",
+                tags=["marathon-game", "gaming-tips"],
+                capture_date=date(2026, 3, 30),
+            )
 
     content = (tmp_path / "Weekly Links — 2026-W14.md").read_text()
-    # Only one Gaming section header
     assert content.count("## Gaming") == 1
-    # All three entries are under the Gaming section, not Other
     gaming_section = content.split("## Gaming")[1].split("## ")[0]
     for i in range(3):
         assert f"[[Marathon Tip {i}]]" in gaming_section
-
-
-def test_no_tags_uses_content_type_fallback(tmp_path):
-    """Entries with no tags use content-type fallback for categorization."""
-    _append_to_weekly_log(
-        inbox_dir=str(tmp_path),
-        title="News Podcast",
-        url="https://example.com/podcast",
-        content_type="podcast",
-        source="ingest-api",
-        tags=[],
-        capture_date=date(2026, 3, 30),
-    )
-
-    content = (tmp_path / "Weekly Links — 2026-W14.md").read_text()
-    assert "## News & Current Events" in content
-    assert "[[News Podcast]]" in content
 
 
 # ---------------------------------------------------------------------------
@@ -420,3 +396,90 @@ def test_categorize_via_llm_returns_reclassify_items():
 
     assert result["category"] == "Gaming"
     assert result["reclassify"] == reclassify_items
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: _append_to_weekly_log with mocked LLM
+# ---------------------------------------------------------------------------
+
+def test_append_uses_llm_categorization(tmp_path):
+    """_append_to_weekly_log uses LLM to pick the section."""
+    llm_result = {"category": "AI & Dev Tools", "reclassify": []}
+
+    with patch("pipeline.summarizer._categorize_via_llm", return_value=llm_result):
+        _append_to_weekly_log(
+            inbox_dir=str(tmp_path),
+            title="Claude Tips",
+            url="https://example.com/tips",
+            content_type="youtube",
+            source="ingest-api",
+            tags=["claude-code"],
+            capture_date=date(2026, 3, 30),
+        )
+
+    content = (tmp_path / "Weekly Links — 2026-W14.md").read_text()
+    assert "## AI & Dev Tools" in content
+    assert "[[Claude Tips]]" in content
+    # Entry is under AI & Dev Tools, not Other
+    ai_section = content.split("## AI & Dev Tools")[1].split("## ")[0]
+    assert "[[Claude Tips]]" in ai_section
+
+
+def test_append_llm_fallback_lands_in_other(tmp_path):
+    """When LLM falls back to Other, entry goes under Other."""
+    llm_result = {"category": "Other", "reclassify": []}
+
+    with patch("pipeline.summarizer._categorize_via_llm", return_value=llm_result):
+        _append_to_weekly_log(
+            inbox_dir=str(tmp_path),
+            title="Random Link",
+            url="https://example.com/random",
+            content_type="web_page",
+            source="cli",
+            tags=[],
+            capture_date=date(2026, 3, 30),
+        )
+
+    content = (tmp_path / "Weekly Links — 2026-W14.md").read_text()
+    other_section = content.split("## Other")[1]
+    assert "[[Random Link]]" in other_section
+
+
+def test_append_with_reclassification(tmp_path):
+    """LLM reclassify instructions move existing entries between sections."""
+    # First entry goes to Other (no LLM reclassify on first call)
+    with patch("pipeline.summarizer._categorize_via_llm",
+               return_value={"category": "Other", "reclassify": []}):
+        _append_to_weekly_log(
+            inbox_dir=str(tmp_path),
+            title="Early AI Article",
+            url="https://example.com/ai1",
+            content_type="web_page",
+            source="ingest-api",
+            tags=[],
+            capture_date=date(2026, 3, 30),
+        )
+
+    # Second entry — LLM now recognizes the AI theme and reclassifies
+    with patch("pipeline.summarizer._categorize_via_llm",
+               return_value={
+                   "category": "AI & Dev Tools",
+                   "reclassify": [{"title": "Early AI Article", "to": "AI & Dev Tools"}],
+               }):
+        _append_to_weekly_log(
+            inbox_dir=str(tmp_path),
+            title="Claude Deep Dive",
+            url="https://example.com/ai2",
+            content_type="youtube",
+            source="ingest-api",
+            tags=["claude-code"],
+            capture_date=date(2026, 3, 31),
+        )
+
+    content = (tmp_path / "Weekly Links — 2026-W14.md").read_text()
+    ai_section = content.split("## AI & Dev Tools")[1].split("## ")[0]
+    assert "[[Claude Deep Dive]]" in ai_section
+    assert "[[Early AI Article]]" in ai_section
+    # Other should no longer have Early AI Article
+    other_section = content.split("## Other")[1]
+    assert "[[Early AI Article]]" not in other_section

--- a/tests/test_weekly_log.py
+++ b/tests/test_weekly_log.py
@@ -1,5 +1,7 @@
+import json
 import os
 import sys
+from unittest.mock import patch, MagicMock
 
 # pipeline/ must be on path so 'from config import ...' resolves inside summarizer
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../pipeline"))
@@ -7,6 +9,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../pipeline"))
 from datetime import date
 from pipeline.summarizer import (
     _append_to_weekly_log,
+    _categorize_via_llm,
     categorize_from_tags,
 )
 
@@ -203,3 +206,92 @@ def test_no_tags_uses_content_type_fallback(tmp_path):
     content = (tmp_path / "Weekly Links — 2026-W14.md").read_text()
     assert "## News & Current Events" in content
     assert "[[News Podcast]]" in content
+
+
+# ---------------------------------------------------------------------------
+# _categorize_via_llm tests
+# ---------------------------------------------------------------------------
+
+def _make_openrouter_response(category: str, reclassify: list | None = None) -> MagicMock:
+    """Build a mock urllib response that returns an OpenRouter-shaped JSON payload."""
+    payload = json.dumps({
+        "choices": [{
+            "message": {
+                "content": json.dumps({
+                    "category": category,
+                    "reclassify": reclassify or [],
+                })
+            }
+        }]
+    }).encode("utf-8")
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = payload
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+def test_categorize_via_llm_picks_existing_section():
+    """LLM response naming an existing section is returned as-is."""
+    existing_sections = {
+        "AI & Dev Tools": ["Some AI Article"],
+        "Gaming": ["Marathon Clip"],
+        "Other": [],
+    }
+
+    mock_resp = _make_openrouter_response("AI & Dev Tools")
+
+    with patch("pipeline.summarizer.get_secret", return_value="fake-key"), \
+         patch("urllib.request.urlopen", return_value=mock_resp):
+        result = _categorize_via_llm(
+            title="Claude Code Tips",
+            url="https://youtube.com/watch?v=abc",
+            content_type="youtube",
+            tags=["claude-code", "ai-agents"],
+            existing_sections=existing_sections,
+        )
+
+    assert result["category"] == "AI & Dev Tools"
+    assert result["reclassify"] == []
+
+
+def test_categorize_via_llm_falls_back_on_api_error():
+    """Any API failure returns the safe fallback dict."""
+    existing_sections = {"Other": []}
+
+    with patch("pipeline.summarizer.get_secret", return_value="fake-key"), \
+         patch("urllib.request.urlopen", side_effect=Exception("connection refused")):
+        result = _categorize_via_llm(
+            title="Some Article",
+            url="https://example.com/article",
+            content_type="web_page",
+            tags=[],
+            existing_sections=existing_sections,
+        )
+
+    assert result == {"category": "Other", "reclassify": []}
+
+
+def test_categorize_via_llm_returns_reclassify_items():
+    """LLM response with reclassify items is returned correctly."""
+    existing_sections = {
+        "AI & Dev Tools": ["Some AI Article"],
+        "Other": ["Random Link", "Old Article"],
+    }
+    reclassify_items = [
+        {"title": "Random Link", "to": "AI & Dev Tools"},
+    ]
+    mock_resp = _make_openrouter_response("Gaming", reclassify_items)
+
+    with patch("pipeline.summarizer.get_secret", return_value="fake-key"), \
+         patch("urllib.request.urlopen", return_value=mock_resp):
+        result = _categorize_via_llm(
+            title="Marathon Highlight",
+            url="https://example.com/marathon",
+            content_type="social_video",
+            tags=["marathon-game"],
+            existing_sections=existing_sections,
+        )
+
+    assert result["category"] == "Gaming"
+    assert result["reclassify"] == reclassify_items

--- a/tests/test_weekly_log.py
+++ b/tests/test_weekly_log.py
@@ -10,6 +10,7 @@ from datetime import date
 from pipeline.summarizer import (
     _append_to_weekly_log,
     _categorize_via_llm,
+    _parse_weekly_sections,
     categorize_from_tags,
 )
 
@@ -206,6 +207,64 @@ def test_no_tags_uses_content_type_fallback(tmp_path):
     content = (tmp_path / "Weekly Links — 2026-W14.md").read_text()
     assert "## News & Current Events" in content
     assert "[[News Podcast]]" in content
+
+
+# ---------------------------------------------------------------------------
+# _parse_weekly_sections tests
+# ---------------------------------------------------------------------------
+
+def test_parse_weekly_sections_basic():
+    """Extracts section names and entry titles from weekly log content."""
+    content = """\
+---
+title: "Weekly Links — 2026-W14"
+---
+# Weekly Links — 2026-W14
+
+## AI & Dev Tools
+- 2026-03-30 — [[Claude Code Tips]] · [youtube](https://yt.com/1) · via ingest-api
+- 2026-03-31 — [[LLM Patterns]] · [web_page](https://example.com) · via cli
+
+## Horror & Film
+- 2026-03-30 — [[Nosferatu Review]] · [web_page](https://example.com/horror) · via ingest-api
+
+## Other
+- 2026-03-31 — [[Random Link]] · [web_page](https://example.com/random) · via ingest-api
+"""
+    result = _parse_weekly_sections(content)
+    assert result == {
+        "AI & Dev Tools": ["Claude Code Tips", "LLM Patterns"],
+        "Horror & Film": ["Nosferatu Review"],
+        "Other": ["Random Link"],
+    }
+
+
+def test_parse_weekly_sections_empty_sections():
+    """Sections with no entries return empty lists."""
+    content = """\
+---
+title: "Weekly Links — 2026-W14"
+---
+# Weekly Links — 2026-W14
+
+## Gaming
+
+## Other
+"""
+    result = _parse_weekly_sections(content)
+    assert result == {"Gaming": [], "Other": []}
+
+
+def test_parse_weekly_sections_no_sections():
+    """File with no ## headers returns empty dict."""
+    content = """\
+---
+title: "Weekly Links — 2026-W14"
+---
+# Weekly Links — 2026-W14
+"""
+    result = _parse_weekly_sections(content)
+    assert result == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace static `TAG_CATEGORY_RULES` (80+ lines of hardcoded tag-to-category mappings) with a single LLM call via OpenRouter/Haiku
- LLM sees existing sections in the weekly log, enabling smarter consolidation and cross-item pattern recognition
- Add reclassification: when a new entry creates a clear theme, the LLM can move earlier "Other" items into the new section
- Graceful fallback to "Other" on any API failure

## Changes

- `_categorize_via_llm()` — asks Haiku to pick the best section, returns category + optional reclassify instructions
- `_parse_weekly_sections()` — extracts `{section: [titles]}` from weekly log markdown
- `_reclassify_entries()` — moves entry lines between sections based on LLM instructions
- Rewired `_append_to_weekly_log()` to use the LLM pipeline instead of `categorize_from_tags()`
- Removed `TAG_CATEGORY_RULES`, `CONTENT_TYPE_FALLBACK_MAP`, and `categorize_from_tags()`

## Test Plan

- [x] 19 weekly log tests pass (all mock the LLM)
- [x] 215/215 total repo tests pass
- [x] Unit tests for each new helper (`_parse_weekly_sections`, `_reclassify_entries`, `_categorize_via_llm`)
- [x] Integration tests for full `_append_to_weekly_log` flow with mocked LLM
- [x] Reclassification integration test verifies items move between sections
- [x] API failure fallback test verifies graceful degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)