### PR TITLE
feat: add pipeline queue, retry, and RSS management tools

### DIFF
--- a/pipeline/db.py
+++ b/pipeline/db.py
@@ -394,6 +394,48 @@ def mark_articles_surfaced(
         conn.close()
 
 
+def get_pipeline_status(
+    recent_limit: int = 20,
+    db_path: str = DB_PATH,
+) -> dict:
+    """Return pipeline queue status: non-done items, recent completions, and counts."""
+    conn = get_connection(db_path)
+    try:
+        # Queue: all non-done items
+        queue_rows = conn.execute(
+            """SELECT id, url, source_type, sender, context, content_type, status,
+                      created_at, updated_at, error, retry_count
+               FROM links
+               WHERE status != 'done'
+               ORDER BY created_at ASC""",
+        ).fetchall()
+
+        # Recent completions
+        recent_rows = conn.execute(
+            """SELECT id, url, source_type, sender, content_type, status,
+                      created_at, updated_at, obsidian_note_path, share_url
+               FROM links
+               WHERE status = 'done'
+               ORDER BY updated_at DESC
+               LIMIT ?""",
+            (recent_limit,),
+        ).fetchall()
+
+        # Counts by status
+        count_rows = conn.execute(
+            "SELECT status, COUNT(*) as count FROM links GROUP BY status"
+        ).fetchall()
+        counts = {row["status"]: row["count"] for row in count_rows}
+
+        return {
+            "queue": [dict(r) for r in queue_rows],
+            "recent": [dict(r) for r in recent_rows],
+            "counts": counts,
+        }
+    finally:
+        conn.close()
+
+
 def expire_old_articles(
     max_age_days: int = 14,
     db_path: str = DB_PATH,

--- a/src/mcp_knowledge/server.py
+++ b/src/mcp_knowledge/server.py
@@ -33,6 +33,7 @@ try:
     from pipeline.db import (
         add_feed as _db_add_feed,
         get_connection as _db_get_connection,
+        get_pipeline_status as _db_get_pipeline_status,
         get_top_articles as _db_get_top_articles,
         list_feeds as _db_list_feeds,
         mark_articles_surfaced as _db_mark_articles_surfaced,
@@ -269,6 +270,43 @@ def manage_feeds(
             conn.close()
 
     return {"error": f"Unknown action '{action}'. Use 'list', 'add', or 'stats'."}
+
+
+# ---------------------------------------------------------------------------
+# Pipeline tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def pipeline_queue(recent_limit: int = 20) -> dict:
+    """Return the current state of the content preservation pipeline.
+
+    Shows items waiting to be processed (pending/processing/error) and
+    recently completed saves. Use this to monitor the Signal-to-Obsidian
+    pipeline health.
+
+    Args:
+        recent_limit: Maximum number of recent completions to include (default 20).
+    """
+    if not _RSS_AVAILABLE:
+        return {"error": "Pipeline db unavailable — pipeline deps not installed"}
+    return _db_get_pipeline_status(recent_limit=recent_limit, db_path=_DB_PATH)
+
+
+@mcp.tool()
+def pipeline_retry(link_id: int) -> dict:
+    """Reset an errored pipeline item back to pending for reprocessing.
+
+    Args:
+        link_id: ID of the link to retry.
+    """
+    if not _RSS_AVAILABLE:
+        return {"error": "Pipeline db unavailable"}
+    from pipeline.db import claim_link
+    success = claim_link(link_id, from_status="error", to_status="pending", db_path=_DB_PATH)
+    if success:
+        return {"retried": True, "link_id": link_id}
+    return {"retried": False, "error": f"Link {link_id} not in error state"}
 
 
 # ---------------------------------------------------------------------------

--- a/src/mcp_knowledge/server.py
+++ b/src/mcp_knowledge/server.py
@@ -225,9 +225,10 @@ def manage_feeds(
       - "list": Return all active feeds with metadata.
       - "add": Add a new feed. Requires url. tier defaults to 2 if omitted.
       - "stats": Return feed and article counts from the database.
+      - "deactivate": Disable a feed by URL (sets active=0). Requires url.
 
     Args:
-        action: One of "list", "add", or "stats".
+        action: One of "list", "add", "stats", or "deactivate".
         url: Feed URL (required for "add").
         title: Human-readable feed title (optional for "add").
         tier: Priority tier 1–3 for scoring (optional for "add", default 2).
@@ -269,7 +270,80 @@ def manage_feeds(
         finally:
             conn.close()
 
-    return {"error": f"Unknown action '{action}'. Use 'list', 'add', or 'stats'."}
+    if action == "deactivate":
+        if not url:
+            return {"error": "url is required for action='deactivate'"}
+        conn = _db_get_connection(_DB_PATH)
+        try:
+            cursor = conn.execute(
+                "UPDATE feeds SET active = 0 WHERE url = ?", (url,)
+            )
+            conn.commit()
+            if cursor.rowcount == 0:
+                return {"error": f"Feed not found: {url}"}
+            return {"deactivated": True, "url": url}
+        finally:
+            conn.close()
+
+    return {"error": f"Unknown action '{action}'. Use 'list', 'add', 'stats', or 'deactivate'."}
+
+
+@mcp.tool()
+def list_all_articles(
+    feed_url: str | None = None,
+    surfaced: bool | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict:
+    """List RSS articles with optional filtering by feed and surfaced status.
+
+    Returns articles ordered by published date (newest first) with pagination.
+
+    Args:
+        feed_url: Filter to articles from this feed URL only.
+        surfaced: Filter by surfaced status (True/False). None = all.
+        limit: Maximum articles to return (default 50).
+        offset: Skip this many articles for pagination (default 0).
+    """
+    if not _RSS_AVAILABLE:
+        return {"error": "RSS db unavailable"}
+    conn = _db_get_connection(_DB_PATH)
+    try:
+        conditions = []
+        params: list = []
+
+        if feed_url:
+            conditions.append("f.url = ?")
+            params.append(feed_url)
+        if surfaced is not None:
+            conditions.append("a.surfaced = ?")
+            params.append(1 if surfaced else 0)
+
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+        # Get total count
+        count_sql = f"SELECT COUNT(*) FROM articles a JOIN feeds f ON a.feed_id = f.id {where}"
+        total = conn.execute(count_sql, params).fetchone()[0]
+
+        # Get page of articles
+        sql = f"""SELECT a.id, a.title, a.url, a.summary, a.score, a.published_at,
+                         a.surfaced, f.title AS feed_title, f.url AS feed_url, f.tier
+                  FROM articles a
+                  JOIN feeds f ON a.feed_id = f.id
+                  {where}
+                  ORDER BY a.published_at DESC
+                  LIMIT ? OFFSET ?"""
+        params.extend([limit, offset])
+        rows = conn.execute(sql, params).fetchall()
+
+        return {
+            "articles": [dict(r) for r in rows],
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        }
+    finally:
+        conn.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline_queue.py
+++ b/tests/test_pipeline_queue.py
@@ -1,0 +1,88 @@
+"""Tests for pipeline_queue tool."""
+import sqlite3
+from datetime import datetime
+
+import pytest
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    """Create a temporary pipeline DB with test data."""
+    path = str(tmp_path / "test.db")
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript("""
+        CREATE TABLE links (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            url TEXT NOT NULL UNIQUE,
+            source_type TEXT,
+            sender TEXT,
+            context TEXT,
+            content_type TEXT,
+            status TEXT NOT NULL DEFAULT 'pending',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            download_path TEXT,
+            transcript_path TEXT,
+            obsidian_note_path TEXT,
+            archive_path TEXT,
+            video_path TEXT,
+            share_url TEXT,
+            error TEXT,
+            retry_count INTEGER NOT NULL DEFAULT 0,
+            metadata TEXT
+        );
+    """)
+    now = datetime.now().isoformat()
+    conn.executemany(
+        """INSERT INTO links (url, source_type, sender, content_type, status, created_at, updated_at, error)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        [
+            ("https://youtube.com/watch?v=abc", "signal", "Mark", "youtube", "pending", now, now, None),
+            ("https://example.com/article", "signal", "Mark", "article", "processing", now, now, None),
+            ("https://broken.com/page", "signal", "Mark", "article", "error", now, now, "timeout"),
+            ("https://done.com/video", "signal", "Mark", "youtube", "done", now, now, None),
+            ("https://done2.com/article", "signal", "Mark", "article", "done", now, now, None),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def test_get_pipeline_status_returns_structure(db_path):
+    from pipeline.db import get_pipeline_status
+    result = get_pipeline_status(db_path=db_path)
+    assert "queue" in result
+    assert "recent" in result
+    assert "counts" in result
+
+
+def test_queue_excludes_done(db_path):
+    from pipeline.db import get_pipeline_status
+    result = get_pipeline_status(db_path=db_path)
+    statuses = {item["status"] for item in result["queue"]}
+    assert "done" not in statuses
+    assert len(result["queue"]) == 3  # pending + processing + error
+
+
+def test_recent_only_done(db_path):
+    from pipeline.db import get_pipeline_status
+    result = get_pipeline_status(db_path=db_path)
+    assert all(item["status"] == "done" for item in result["recent"])
+    assert len(result["recent"]) == 2
+
+
+def test_counts_correct(db_path):
+    from pipeline.db import get_pipeline_status
+    result = get_pipeline_status(db_path=db_path)
+    assert result["counts"]["pending"] == 1
+    assert result["counts"]["processing"] == 1
+    assert result["counts"]["error"] == 1
+    assert result["counts"]["done"] == 2
+
+
+def test_recent_limit(db_path):
+    from pipeline.db import get_pipeline_status
+    result = get_pipeline_status(recent_limit=1, db_path=db_path)
+    assert len(result["recent"]) == 1

--- a/tests/test_rss_tools.py
+++ b/tests/test_rss_tools.py
@@ -1,0 +1,185 @@
+"""Tests for RSS feed management tools: manage_feeds(deactivate) and list_all_articles."""
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+from datetime import datetime, timezone
+
+from pipeline.db import init_db, add_feed, add_article, get_connection
+from mcp_knowledge import server as server_mod
+
+
+@pytest.fixture()
+def rss_db(tmp_path, monkeypatch):
+    """Create a temporary RSS DB with test data and patch _DB_PATH."""
+    db_path = str(tmp_path / "test.db")
+    init_db(db_path)
+
+    monkeypatch.setattr(server_mod, "_DB_PATH", db_path)
+    monkeypatch.setattr(server_mod, "_RSS_AVAILABLE", True)
+
+    now = datetime.now(timezone.utc).isoformat()
+
+    fid1 = add_feed(
+        url="https://example.com/feed.xml",
+        title="Example Feed",
+        tier=1,
+        db_path=db_path,
+    )
+    fid2 = add_feed(
+        url="https://other.com/feed.xml",
+        title="Other Feed",
+        tier=2,
+        db_path=db_path,
+    )
+
+    # 5 articles on feed 1: all inserted as unsurfaced (add_article default)
+    for i in range(5):
+        add_article(
+            feed_id=fid1,
+            guid=f"guid-{i}",
+            title=f"Article {i}",
+            url=f"https://example.com/{i}",
+            summary=f"Summary {i}",
+            published_at=now,
+            score=0.5,
+            db_path=db_path,
+        )
+
+    # 2 articles on feed 2: unsurfaced
+    for i in range(2):
+        add_article(
+            feed_id=fid2,
+            guid=f"other-guid-{i}",
+            title=f"Other Article {i}",
+            url=f"https://other.com/{i}",
+            summary=f"Other Summary {i}",
+            published_at=now,
+            score=0.3,
+            db_path=db_path,
+        )
+
+    # Mark articles 3 and 4 (guids guid-3, guid-4) as surfaced directly in DB
+    conn = get_connection(db_path)
+    conn.execute(
+        "UPDATE articles SET surfaced = 1 WHERE guid IN (?, ?)", ("guid-3", "guid-4")
+    )
+    conn.commit()
+    conn.close()
+
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# list_all_articles
+# ---------------------------------------------------------------------------
+
+
+class TestListAllArticles:
+    def test_returns_all_articles_default(self, rss_db):
+        result = server_mod.list_all_articles()
+        assert "articles" in result
+        assert "total" in result
+        assert "limit" in result
+        assert "offset" in result
+        assert result["total"] == 7
+        assert len(result["articles"]) == 7
+
+    def test_articles_have_expected_keys(self, rss_db):
+        result = server_mod.list_all_articles()
+        article = result["articles"][0]
+        required = {"id", "title", "url", "summary", "score", "published_at",
+                    "surfaced", "feed_title", "feed_url", "tier"}
+        assert required.issubset(set(article.keys()))
+
+    def test_filter_by_feed_url(self, rss_db):
+        result = server_mod.list_all_articles(feed_url="https://example.com/feed.xml")
+        assert result["total"] == 5
+        assert len(result["articles"]) == 5
+        for article in result["articles"]:
+            assert article["feed_url"] == "https://example.com/feed.xml"
+
+    def test_filter_by_surfaced_false(self, rss_db):
+        result = server_mod.list_all_articles(surfaced=False)
+        assert result["total"] == 5  # 3 from feed1 + 2 from feed2
+        assert len(result["articles"]) == 5
+        for article in result["articles"]:
+            assert article["surfaced"] == 0
+
+    def test_filter_by_surfaced_true(self, rss_db):
+        result = server_mod.list_all_articles(surfaced=True)
+        assert result["total"] == 2  # 2 surfaced from feed1
+        assert len(result["articles"]) == 2
+        for article in result["articles"]:
+            assert article["surfaced"] == 1
+
+    def test_filter_by_feed_url_and_surfaced(self, rss_db):
+        result = server_mod.list_all_articles(
+            feed_url="https://example.com/feed.xml",
+            surfaced=False,
+        )
+        assert result["total"] == 3
+
+    def test_pagination_limit(self, rss_db):
+        result = server_mod.list_all_articles(limit=3)
+        assert result["total"] == 7
+        assert len(result["articles"]) == 3
+        assert result["limit"] == 3
+
+    def test_pagination_offset(self, rss_db):
+        result_page1 = server_mod.list_all_articles(limit=4, offset=0)
+        result_page2 = server_mod.list_all_articles(limit=4, offset=4)
+        ids_page1 = {a["id"] for a in result_page1["articles"]}
+        ids_page2 = {a["id"] for a in result_page2["articles"]}
+        # Pages must not overlap
+        assert ids_page1.isdisjoint(ids_page2)
+        # Together they cover all articles
+        assert len(ids_page1 | ids_page2) == 7
+
+    def test_returns_error_when_rss_unavailable(self, monkeypatch):
+        monkeypatch.setattr(server_mod, "_RSS_AVAILABLE", False)
+        result = server_mod.list_all_articles()
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# manage_feeds — deactivate action
+# ---------------------------------------------------------------------------
+
+
+class TestManageFeedsDeactivate:
+    def test_deactivate_existing_feed(self, rss_db):
+        result = server_mod.manage_feeds(
+            action="deactivate",
+            url="https://example.com/feed.xml",
+        )
+        assert result == {"deactivated": True, "url": "https://example.com/feed.xml"}
+
+    def test_deactivated_feed_excluded_from_list(self, rss_db):
+        server_mod.manage_feeds(action="deactivate", url="https://example.com/feed.xml")
+        feeds = server_mod.manage_feeds(action="list")
+        urls = [f["url"] for f in feeds]
+        assert "https://example.com/feed.xml" not in urls
+
+    def test_deactivate_unknown_feed_returns_error(self, rss_db):
+        result = server_mod.manage_feeds(
+            action="deactivate",
+            url="https://nonexistent.com/feed.xml",
+        )
+        assert "error" in result
+        assert "nonexistent" in result["error"]
+
+    def test_deactivate_without_url_returns_error(self, rss_db):
+        result = server_mod.manage_feeds(action="deactivate")
+        assert "error" in result
+        assert "url is required" in result["error"]
+
+    def test_deactivate_returns_error_when_rss_unavailable(self, monkeypatch):
+        monkeypatch.setattr(server_mod, "_RSS_AVAILABLE", False)
+        result = server_mod.manage_feeds(
+            action="deactivate",
+            url="https://example.com/feed.xml",
+        )
+        assert "error" in result

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -55,7 +55,7 @@ class TestToolRegistration:
         expected = {
             "search_knowledge", "list_topics", "get_document", "get_server_info",
             "list_recent_articles", "search_articles", "mark_surfaced",
-            "manage_feeds",
+            "manage_feeds", "list_all_articles", "pipeline_queue", "pipeline_retry",
         }
         assert expected == tool_names, (
             f"Expected tools {expected}, got {tool_names}"


### PR DESCRIPTION
## Summary

- **pipeline_queue** — returns queue (non-done items), recent completions, and status counts for the Signal-to-Obsidian pipeline
- **pipeline_retry** — resets an errored item back to pending for reprocessing
- **manage_feeds deactivate** — new action to disable a feed by URL (sets active=0)
- **list_all_articles** — paginated article browser with feed/surfaced filtering

## Context

These tools power the dashboard pipeline view (second-brain#33). The dashboard calls pipeline_queue for the status board, pipeline_retry for error recovery, manage_feeds for feed management, and list_all_articles for the article browser.

## Test plan

- [ ] 19 new tests across test_pipeline_queue.py and test_rss_tools.py
- [ ] All 35 collectable tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)