### PR TITLE
fix: restore MCP resources and correct pipeline status query

### DIFF
--- a/pipeline/db.py
+++ b/pipeline/db.py
@@ -398,24 +398,24 @@ def get_pipeline_status(
     recent_limit: int = 20,
     db_path: str = DB_PATH,
 ) -> dict:
-    """Return pipeline queue status: non-done items, recent completions, and counts."""
+    """Return pipeline queue status: in-progress items, recent completions, and counts."""
     conn = get_connection(db_path)
     try:
-        # Queue: all non-done items
+        # Queue: items still in progress (not archived or failed)
         queue_rows = conn.execute(
             """SELECT id, url, source_type, sender, context, content_type, status,
                       created_at, updated_at, error, retry_count
                FROM links
-               WHERE status != 'done'
+               WHERE status NOT IN ('archived', 'failed')
                ORDER BY created_at ASC""",
         ).fetchall()
 
-        # Recent completions
+        # Recent completions (archived items)
         recent_rows = conn.execute(
             """SELECT id, url, source_type, sender, content_type, status,
                       created_at, updated_at, obsidian_note_path, share_url
                FROM links
-               WHERE status = 'done'
+               WHERE status = 'archived'
                ORDER BY updated_at DESC
                LIMIT ?""",
             (recent_limit,),

--- a/src/mcp_knowledge/mcp_adapter.py
+++ b/src/mcp_knowledge/mcp_adapter.py
@@ -10,7 +10,14 @@ import json
 import logging
 
 from mcp.server import Server
-from mcp.types import TextContent, Tool
+from mcp.types import (
+    ReadResourceResult,
+    Resource,
+    ResourceTemplate,
+    TextContent,
+    TextResourceContents,
+    Tool,
+)
 
 from . import config, knowledge
 
@@ -477,6 +484,61 @@ _TOOLS: list[Tool] = [
 def create_mcp_server() -> Server:
     """Build and return the crows-nest MCP Server."""
     server = Server("crows-nest")
+
+    # ------------------------------------------------------------------
+    # Resources
+    # ------------------------------------------------------------------
+
+    @server.list_resources()
+    async def list_resources() -> list[Resource]:
+        return [
+            Resource(
+                uri="knowledge://sources",
+                name="Knowledge sources",
+                description="The sources.json manifest — lists all knowledge source documents and metadata.",
+                mimeType="application/json",
+            ),
+            Resource(
+                uri="knowledge://documents",
+                name="Document list",
+                description="All available document paths, one per line.",
+                mimeType="text/plain",
+            ),
+        ]
+
+    @server.list_resource_templates()
+    async def list_resource_templates() -> list[ResourceTemplate]:
+        return [
+            ResourceTemplate(
+                uriTemplate="knowledge://document/{path}",
+                name="Knowledge document",
+                description="Read a specific knowledge document by its relative path.",
+                mimeType="text/plain",
+            ),
+        ]
+
+    @server.read_resource()
+    async def read_resource(uri) -> ReadResourceResult:
+        uri_str = str(uri)
+
+        if uri_str == "knowledge://sources":
+            text = json.dumps(knowledge.load_sources(), indent=2)
+        elif uri_str == "knowledge://documents":
+            text = "\n".join(knowledge.list_documents())
+        elif uri_str.startswith("knowledge://document/"):
+            path = uri_str[len("knowledge://document/"):]
+            content = knowledge.get_document(path)
+            text = content if content is not None else f"Document not found: {path}"
+        else:
+            text = f"Unknown resource: {uri_str}"
+
+        return ReadResourceResult(
+            contents=[TextResourceContents(uri=uri_str, text=text, mimeType="text/plain")]
+        )
+
+    # ------------------------------------------------------------------
+    # Tools
+    # ------------------------------------------------------------------
 
     @server.list_tools()
     async def list_tools() -> list[Tool]:

--- a/tests/test_pipeline_queue.py
+++ b/tests/test_pipeline_queue.py
@@ -41,8 +41,8 @@ def db_path(tmp_path):
             ("https://youtube.com/watch?v=abc", "signal", "Mark", "youtube", "pending", now, now, None),
             ("https://example.com/article", "signal", "Mark", "article", "processing", now, now, None),
             ("https://broken.com/page", "signal", "Mark", "article", "error", now, now, "timeout"),
-            ("https://done.com/video", "signal", "Mark", "youtube", "done", now, now, None),
-            ("https://done2.com/article", "signal", "Mark", "article", "done", now, now, None),
+            ("https://done.com/video", "signal", "Mark", "youtube", "archived", now, now, None),
+            ("https://done2.com/article", "signal", "Mark", "article", "archived", now, now, None),
         ],
     )
     conn.commit()
@@ -62,14 +62,14 @@ def test_queue_excludes_done(db_path):
     from pipeline.db import get_pipeline_status
     result = get_pipeline_status(db_path=db_path)
     statuses = {item["status"] for item in result["queue"]}
-    assert "done" not in statuses
+    assert "archived" not in statuses
     assert len(result["queue"]) == 3  # pending + processing + error
 
 
 def test_recent_only_done(db_path):
     from pipeline.db import get_pipeline_status
     result = get_pipeline_status(db_path=db_path)
-    assert all(item["status"] == "done" for item in result["recent"])
+    assert all(item["status"] == "archived" for item in result["recent"])
     assert len(result["recent"]) == 2
 
 
@@ -79,7 +79,7 @@ def test_counts_correct(db_path):
     assert result["counts"]["pending"] == 1
     assert result["counts"]["processing"] == 1
     assert result["counts"]["error"] == 1
-    assert result["counts"]["done"] == 2
+    assert result["counts"]["archived"] == 2
 
 
 def test_recent_limit(db_path):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -24,6 +24,7 @@ from mcp_knowledge.mcp_adapter import (
     _search_knowledge,
     create_mcp_server,
 )
+from mcp.types import ListResourcesRequest, ListResourceTemplatesRequest
 
 
 # ---------------------------------------------------------------------------
@@ -83,6 +84,30 @@ class TestToolRegistration:
         assert expected == tool_names, (
             f"Expected tools {expected}, got {tool_names}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Resource registration
+# ---------------------------------------------------------------------------
+
+
+class TestResourceRegistration:
+    def test_static_resources_registered(self) -> None:
+        server = create_mcp_server()
+        handler = server.request_handlers[ListResourcesRequest]
+        req = ListResourcesRequest(method="resources/list", params=None)
+        result = asyncio.run(handler(req))
+        uris = {str(r.uri) for r in result.root.resources}
+        assert "knowledge://sources" in uris
+        assert "knowledge://documents" in uris
+
+    def test_template_resource_registered(self) -> None:
+        server = create_mcp_server()
+        handler = server.request_handlers[ListResourceTemplatesRequest]
+        req = ListResourceTemplatesRequest(method="resources/templates/list", params=None)
+        result = asyncio.run(handler(req))
+        uri_templates = {t.uriTemplate for t in result.root.resourceTemplates}
+        assert "knowledge://document/{path}" in uri_templates
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Restores 3 MCP resource registrations (`knowledge://sources`, `knowledge://documents`, `knowledge://document/{path}`) that were dropped during the API-first migration (#86)
- Fixes `get_pipeline_status` to use `'archived'` (the actual terminal status) instead of nonexistent `'done'` status
- Adds resource registration tests back to `test_server.py`

## Test plan
- [x] All 227 tests pass (`pytest tests/ --ignore=tests/test_rss_listener.py`)
- [ ] After merge + brain-start restart, verify `curl http://127.0.0.1:27185/health` returns 200
- [ ] Verify MCP resource listing works via Claude Code crows-nest tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)