### PR TITLE
fix: add run_at_startup to critical pipeline jobs

### DIFF
--- a/src/mcp_knowledge/scheduler.py
+++ b/src/mcp_knowledge/scheduler.py
@@ -26,18 +26,21 @@ def create_scheduler() -> Scheduler:
         "ingest-poll",
         cmd("ingest_poller.py"),
         interval_seconds=300,
+        run_at_startup=True,
         cwd=cwd,
     )
     scheduler.register_subprocess(
         "obsidian-scan",
         cmd("obsidian_scanner.py"),
         interval_seconds=300,
+        run_at_startup=True,
         cwd=cwd,
     )
     scheduler.register_subprocess(
         "process",
         cmd("processor.py", "--drain"),
         interval_seconds=1800,
+        run_at_startup=True,
         cwd=cwd,
     )
     scheduler.register_subprocess(
@@ -50,6 +53,7 @@ def create_scheduler() -> Scheduler:
         "summarize",
         cmd("summarizer.py", "--drain"),
         interval_seconds=2 * 3600,
+        run_at_startup=True,
         cwd=cwd,
     )
     scheduler.register_subprocess(


### PR DESCRIPTION
## Summary
- Adds `run_at_startup=True` to ingest-poll, obsidian-scan, process, and summarize scheduler jobs
- Without this, all jobs sleep for their full interval (5min–2hr) before first execution after a service restart, leaving the dashboard empty

## Test plan
- [x] Services restarted and verified all startup jobs fired within 30s
- [x] Summarizer drained 10 queued items successfully after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)